### PR TITLE
APM-901 Env cleaning process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # Emacs
 .#*
+
+# Local access tokens
+.access_token

--- a/apigee_client.py
+++ b/apigee_client.py
@@ -48,19 +48,25 @@ class ApigeeClient:
         )
         return response.json()
 
+    def list_env_proxy_deployments(self, env: str):
+        response = self.get(
+            f"https://api.enterprise.apigee.com/v1/organizations/{self.apigee_org}/environments/{env}/deployments"
+        )
+        return response.json()
+
     def get_proxy(self, proxy):
         response = self.get(
             f"https://api.enterprise.apigee.com/v1/organizations/{self.apigee_org}/apis/{proxy}"
         )
         return response.json()
 
-    def get_proxy_revision(self, proxy, revision):
+    def get_proxy_revision(self, proxy: str, revision: str):
         response = self.get(
             f"https://api.enterprise.apigee.com/v1/organizations/{self.apigee_org}/apis/{proxy}/revisions/{revision}"
         )
         return response.json()
 
-    def undeploy_proxy_revision(self, env, proxy, revision):
+    def undeploy_proxy_revision(self, env: str, proxy: str, revision: str):
         response = self.delete(
             f"https://api.enterprise.apigee.com/v1/organizations/{self.apigee_org}/environments/{env}/apis/{proxy}/revisions/{revision}/deployments"
         )

--- a/apigee_client.py
+++ b/apigee_client.py
@@ -13,7 +13,7 @@ class ApigeeClient:
         username: str = None,
         password: str = None,
         access_token: str = None,
-        session: requests.Session = requests.Session(),
+        session: requests.Session = requests.Session()
     ):
         self.apigee_org = apigee_org
 
@@ -42,6 +42,49 @@ class ApigeeClient:
     head = partialmethod(_request, "HEAD")
     options = partialmethod(_request, "OPTIONS")
 
+    def list_proxies(self):
+        response = self.get(
+            f"https://api.enterprise.apigee.com/v1/organizations/{self.apigee_org}/apis"
+        )
+        return response.json()
+
+    def get_proxy(self, proxy):
+        response = self.get(
+            f"https://api.enterprise.apigee.com/v1/organizations/{self.apigee_org}/apis/{proxy}"
+        )
+        return response.json()
+
+    def get_proxy_revision(self, proxy, revision):
+        response = self.get(
+            f"https://api.enterprise.apigee.com/v1/organizations/{self.apigee_org}/apis/{proxy}/revisions/{revision}"
+        )
+        return response.json()
+
+    def undeploy_proxy_revision(self, env, proxy, revision):
+        response = self.delete(
+            f"https://api.enterprise.apigee.com/v1/organizations/{self.apigee_org}/environments/{env}/apis/{proxy}/revisions/{revision}/deployments"
+        )
+        return response.json()
+
+    def delete_proxy(self, proxy: str):
+        response = self.delete(
+            f"https://api.enterprise.apigee.com/v1/organizations/{self.apigee_org}/apis/{proxy}"
+        )
+        return response.json()
+
+    def list_products(self):
+        response = self.get(
+            f"https://api.enterprise.apigee.com/v1/organizations/{self.apigee_org}/apiproducts"
+        )
+        return response.json()
+
+    def delete_product(self, product: str):
+        # TODO implement cascade behaviour
+        response = self.delete(
+            f"https://api.enterprise.apigee.com/v1/organizations/{self.apigee_org}/apiproducts/{product}"
+        )
+        return response.json()
+
     def list_specs(self):
         response = self.get(
             f"https://apigee.com/dapi/api/organizations/{self.apigee_org}/specs/folder/home"
@@ -60,6 +103,12 @@ class ApigeeClient:
             f"https://apigee.com/dapi/api/organizations/{self.apigee_org}/specs/doc/{spec_id}/content",
             headers=dict(**{"Content-Type": "text/plain"}, **self._auth_headers),
             data=content.encode("utf-8"),
+        )
+        return response
+
+    def delete_spec(self, spec_id: str):
+        response = self.delete(
+            f"https://apigee.com/dapi/api/organizations/{self.apigee_org}/specs/doc/{spec_id}",
         )
         return response
 

--- a/env_cleaner.py
+++ b/env_cleaner.py
@@ -4,8 +4,8 @@ env_cleaner.py
 A tool for cleaning up apigee-envs
 
 Usage:
-  spec_uploader.py <apigee_org> <apigee_env> --access-token=<access_token> [--specs] [--proxies] [--products] [--sandbox-only] [--dry-run] [--min-age=<min_age>] [--undeploy-only]
-  spec_uploader.py (-h | --help)
+  env_cleaner.py <apigee_org> <apigee_env> --access-token=<access_token> [--specs] [--proxies] [--products] [--sandbox-only] [--dry-run] [--min-age=<min_age>] [--undeploy-only]
+  env_cleaner.py (-h | --help)
 
 Options:
   -h --help                      Show this screen

--- a/env_cleaner.py
+++ b/env_cleaner.py
@@ -1,0 +1,120 @@
+"""
+env_cleaner.py
+
+A tool for cleaning up apigee-envs
+
+Usage:
+  spec_uploader.py <apigee_org> <apigee_env> --access-token=<access_token> [--specs] [--proxies] [--products] [--sandbox-only] [--dry-run] [--min-age=<min_age>] [--undeploy-only]
+  spec_uploader.py (-h | --help)
+
+Options:
+  -h --help                      Show this screen
+  --access-token=<access_token>  Apigee access token to authorise requests
+  --specs                        Prune specs
+  --proxies                      Prune proxies
+  --products                     Prune products
+  --sandbox-only                 Only delete sandbox proxies
+  --dry-run                      Print a listing of what will be deleted, but don't delete it.
+  --undeploy-only                Don't delete any proxies, just undeploy them
+  --min-age=<min_age>            Minimum age in seconds
+"""
+import re
+import requests
+from typing import Optional
+from docopt import docopt
+from apigee_client import ApigeeClient
+
+
+SPEC_MATCHER = re.compile("(personal-demographics|identity-service|hello-world)-.+")
+PROXY_MATCHER = re.compile(
+    "(personal-demographics|identity-service|hello-world)-internal-dev-.+"
+)
+PRODUCT_MATCHER = PROXY_MATCHER
+SANDBOX_MATCHER = re.compile(".+-sandbox$")
+SANDBOX_ANTIMATCHER = re.compile(".+-internal-qa-sandbox")
+
+
+def clean_specs(client: ApigeeClient, env: str, dry_run: bool = False):
+    specs = client.list_specs()
+    spec_names = [spec["name"] for spec in specs["contents"]]
+
+    # Use the spec matcher to find specs that look like something we'd want to clean
+    pr_specs = [spec for spec in spec_names if SPEC_MATCHER.match(spec)]
+
+    for spec in pr_specs:
+        print(f"DELETE SPEC {spec}")
+        if not dry_run:
+            client.delete_spec(spec)
+            print(f"DELETED SPEC {spec}")
+
+
+def clean_proxies(
+        client: ApigeeClient, env: str, dry_run: bool = False, sandboxes_only: bool = False, min_age: Optional[int] = None, undeploy_only: bool = False
+):
+    proxies = client.list_proxies()
+    pr_proxies = [proxy for proxy in proxies if PROXY_MATCHER.match(proxy)]
+
+    if sandboxes_only:
+        pr_proxies = [proxy for proxy in proxies if SANDBOX_MATCHER.match(proxy) and not SANDBOX_ANTIMATCHER.match(proxy)]
+
+    for proxy in pr_proxies:
+        proxy_info = client.get_proxy(proxy)
+        for revision in proxy_info['revision']:
+            print(f"UNDEPLOY {proxy} REVISION {revision}")
+            if not dry_run:
+                try:
+                    client.undeploy_proxy_revision(env, proxy, revision)
+                except requests.exceptions.HTTPError as e:
+                    print(f"ERROR UNDEPLOYING {proxy} REVISION {revision}: may already be undeployed")
+
+        if not undeploy_only:
+            print(f"DELETE PROXY {proxy}")
+            if not dry_run:
+                client.delete_proxy(proxy)
+
+
+def clean_products(client: ApigeeClient, env: str, dry_run: bool = False):
+    products = client.list_products()
+    pr_products = [product for product in products if PRODUCT_MATCHER.match(product)]
+
+    for product in pr_products:
+        print(f"DELETE PRODUCT {product}")
+        if not dry_run:
+            client.delete_product(product)
+
+
+def clean_env(
+    client: ApigeeClient,
+    env: str,
+    should_clean_specs: bool = False,
+    should_clean_proxies: bool = False,
+    should_clean_products: bool = False,
+    sandboxes_only: bool = False,
+    dry_run: bool = False,
+    min_age: Optional[int] = None,
+    undeploy_only: bool = False
+):
+    if should_clean_specs:
+        clean_specs(client, env, dry_run)
+
+    if should_clean_proxies:
+        clean_proxies(client, env, dry_run, sandboxes_only, min_age, undeploy_only)
+
+    if should_clean_products:
+        clean_products(client, env, dry_run)
+
+
+if __name__ == "__main__":
+    args = docopt(__doc__)
+    client = ApigeeClient(args["<apigee_org>"], access_token=args["--access-token"])
+    clean_env(
+        client,
+        args["<apigee_env>"],
+        should_clean_specs=args["--specs"],
+        should_clean_proxies=args["--proxies"],
+        should_clean_products=args["--products"],
+        sandboxes_only=args["--sandbox-only"],
+        dry_run=args["--dry-run"],
+        min_age=args["--min-age"],
+        undeploy_only=args["--undeploy-only"]
+    )

--- a/env_cleaner_test.py
+++ b/env_cleaner_test.py
@@ -16,12 +16,36 @@ def list_proxies_response():
     return [
         "personal-demographics-internal-dev",
         "personal-demographics-internal-dev-test",
+        "personal-demographics-internal-dev-test-not-deployed",
         "personal-demographics-internal-dev-test-sandbox",
     ]
 
 
+def list_env_proxy_deployments_response(_):
+    return {
+        "aPIProxy": [  # Again, not a typo
+            {
+                "name": "personal-demographics-internal-dev",
+                "revision": [{"name": "1", "state": "deployed"}]
+            },
+            {
+                "name": "personal-demographics-internal-dev-test",
+                "revision": [{"name": "1", "state": "deployed"}]
+            },
+            {
+                "name": "personal-demographics-internal-dev-test-sandbox",
+                "revision": [{"name": "1", "state": "deployed"}]
+            },
+        ]
+    }
+
+
 def list_products_response():
-    return list_proxies_response()  # Left intentionally because they usually match up
+    return [
+        "personal-demographics-internal-dev",
+        "personal-demographics-internal-dev-test",
+        "personal-demographics-internal-dev-test-sandbox",
+    ]
 
 
 def get_proxy_response(proxy):
@@ -37,6 +61,8 @@ def client():
         list_proxies.side_effect = list_proxies_response
         list_products = Mock()
         list_products.side_effect = list_products_response
+        list_env_proxy_deployments = Mock()
+        list_env_proxy_deployments.side_effect = list_env_proxy_deployments_response
         get_proxy = Mock()
         get_proxy.side_effect = get_proxy_response
         undeploy_proxy_revision = Mock()
@@ -59,6 +85,8 @@ def test_clean_everything(client):
         undeploy_only=False,
     )
 
+    client.list_env_proxy_deployments("blah")
+
     client.list_specs.assert_called()
     client.list_proxies.assert_called()
     client.list_products.assert_called()
@@ -66,6 +94,7 @@ def test_clean_everything(client):
     client.get_proxy.assert_has_calls(
         [
             call("personal-demographics-internal-dev-test"),
+            call("personal-demographics-internal-dev-test-not-deployed"),
             call("personal-demographics-internal-dev-test-sandbox"),
         ]
     )
@@ -80,6 +109,7 @@ def test_clean_everything(client):
     client.delete_proxy.assert_has_calls(
         [
             call("personal-demographics-internal-dev-test"),
+            call("personal-demographics-internal-dev-test-not-deployed"),
             call("personal-demographics-internal-dev-test-sandbox"),
         ]
     )
@@ -98,6 +128,7 @@ def test_proxy_dry_run(client):
     client.get_proxy.assert_has_calls(
         [
             call("personal-demographics-internal-dev-test"),
+            call("personal-demographics-internal-dev-test-not-deployed"),
             call("personal-demographics-internal-dev-test-sandbox"),
         ]
     )
@@ -113,7 +144,7 @@ def test_proxy_sandboxes_only(client):
     client.list_proxies.assert_called()
     client.get_proxy.assert_has_calls(
         [
-            call("personal-demographics-internal-dev-test-sandbox")
+            call("personal-demographics-internal-dev-test-sandbox"),
         ]
     )
     client.undeploy_proxy_revision.assert_has_calls(
@@ -133,6 +164,7 @@ def test_proxy_undeploy_only(client):
     client.get_proxy.assert_has_calls(
         [
             call("personal-demographics-internal-dev-test"),
+            call("personal-demographics-internal-dev-test-not-deployed"),
             call("personal-demographics-internal-dev-test-sandbox"),
         ]
     )

--- a/env_cleaner_test.py
+++ b/env_cleaner_test.py
@@ -1,0 +1,145 @@
+import pytest
+import env_cleaner
+from unittest.mock import Mock, call
+
+
+def list_specs_response():
+    return {
+        "contents": [
+            {"name": "personal-demographics"},
+            {"name": "personal-demographics-test"},
+        ]
+    }
+
+
+def list_proxies_response():
+    return [
+        "personal-demographics-internal-dev",
+        "personal-demographics-internal-dev-test",
+        "personal-demographics-internal-dev-test-sandbox",
+    ]
+
+
+def list_products_response():
+    return list_proxies_response()  # Left intentionally because they usually match up
+
+
+def get_proxy_response(proxy):
+    return {"revision": ["1"]}
+
+
+@pytest.fixture
+def client():
+    class FakeApigeeClient:
+        list_specs = Mock()
+        list_specs.side_effect = list_specs_response
+        list_proxies = Mock()
+        list_proxies.side_effect = list_proxies_response
+        list_products = Mock()
+        list_products.side_effect = list_products_response
+        get_proxy = Mock()
+        get_proxy.side_effect = get_proxy_response
+        undeploy_proxy_revision = Mock()
+        delete_proxy = Mock()
+        delete_spec = Mock()
+        delete_product = Mock()
+
+    return FakeApigeeClient()
+
+
+def test_clean_everything(client):
+    env_cleaner.clean_env(
+        client,
+        "test_env",
+        should_clean_specs=True,
+        should_clean_proxies=True,
+        should_clean_products=True,
+        sandboxes_only=False,
+        dry_run=False,
+        undeploy_only=False,
+    )
+
+    client.list_specs.assert_called()
+    client.list_proxies.assert_called()
+    client.list_products.assert_called()
+
+    client.get_proxy.assert_has_calls(
+        [
+            call("personal-demographics-internal-dev-test"),
+            call("personal-demographics-internal-dev-test-sandbox"),
+        ]
+    )
+
+    client.delete_spec.assert_called_with("personal-demographics-test")
+    client.undeploy_proxy_revision.assert_has_calls(
+        [
+            call("test_env", "personal-demographics-internal-dev-test", "1"),
+            call("test_env", "personal-demographics-internal-dev-test-sandbox", "1"),
+        ]
+    )
+    client.delete_proxy.assert_has_calls(
+        [
+            call("personal-demographics-internal-dev-test"),
+            call("personal-demographics-internal-dev-test-sandbox"),
+        ]
+    )
+    client.delete_product.assert_has_calls(
+        [
+            call("personal-demographics-internal-dev-test"),
+            call("personal-demographics-internal-dev-test-sandbox"),
+        ]
+    )
+
+
+def test_proxy_dry_run(client):
+    env_cleaner.clean_env(client, "test_env", should_clean_proxies=True, dry_run=True)
+
+    client.list_proxies.assert_called()
+    client.get_proxy.assert_has_calls(
+        [
+            call("personal-demographics-internal-dev-test"),
+            call("personal-demographics-internal-dev-test-sandbox"),
+        ]
+    )
+    client.undeploy_proxy_revision.assert_not_called()
+    client.delete_proxy.assert_not_called()
+
+
+def test_proxy_sandboxes_only(client):
+    env_cleaner.clean_env(
+        client, "test_env", should_clean_proxies=True, sandboxes_only=True
+    )
+
+    client.list_proxies.assert_called()
+    client.get_proxy.assert_has_calls(
+        [
+            call("personal-demographics-internal-dev-test-sandbox")
+        ]
+    )
+    client.undeploy_proxy_revision.assert_has_calls(
+        [call("test_env", "personal-demographics-internal-dev-test-sandbox", "1"),]
+    )
+    client.delete_proxy.assert_has_calls(
+        [call("personal-demographics-internal-dev-test-sandbox")]
+    )
+
+
+def test_proxy_undeploy_only(client):
+    env_cleaner.clean_env(
+        client, "test_env", should_clean_proxies=True, undeploy_only=True
+    )
+
+    client.list_proxies.assert_called()
+    client.get_proxy.assert_has_calls(
+        [
+            call("personal-demographics-internal-dev-test"),
+            call("personal-demographics-internal-dev-test-sandbox"),
+        ]
+    )
+    client.undeploy_proxy_revision.assert_has_calls(
+        [
+            call("test_env", "personal-demographics-internal-dev-test", "1"),
+            call("test_env", "personal-demographics-internal-dev-test-sandbox", "1"),
+        ]
+    )
+    client.delete_proxy.assert_not_called()


### PR DESCRIPTION
Adding in a script that can clean up crud that has built up over time.

Here's an example usage (undeploy sandbox proxies, i.e. the ones that have been tying up hosted targets):
```bash
$ poetry run python env_cleaner.py nhsd-nonprod internal-dev --proxies --sandbox-only --access-token=`cat .access_token` --undeploy-only
```

Here's the help text:
```
env_cleaner.py

A tool for cleaning up apigee-envs

Usage:
  spec_uploader.py <apigee_org> <apigee_env> --access-token=<access_token> [--specs] [--proxies] [--products] [--sandbox-only] [--dry-run] [--min-age=<min_age>] [--undeploy-only]
  spec_uploader.py (-h | --help)

Options:
  -h --help                      Show this screen
  --access-token=<access_token>  Apigee access token to authorise requests
  --specs                        Prune specs
  --proxies                      Prune proxies
  --products                     Prune products
  --sandbox-only                 Only delete sandbox proxies
  --dry-run                      Print a listing of what will be deleted, but don't delete it.
  --undeploy-only                Don't delete any proxies, just undeploy them
  --min-age=<min_age>            Minimum age in seconds
```