### PR TITLE
APM-1100: Upload and deploy proxies with ansible

### DIFF
--- a/ansible/deploy-apigee-proxy.yml
+++ b/ansible/deploy-apigee-proxy.yml
@@ -5,6 +5,7 @@
 
   vars:
     SERVICE_NAME: "{{ lookup('env', 'SERVICE_NAME') }}"
+    SERVICE_BASE_PATH: "{{ lookup('env', 'SERVICE_BASE_PATH') }}"
     APIGEE_ENVIRONMENT: "{{ lookup('env','APIGEE_ENVIRONMENT') }}"
     APIGEE_ORGANIZATION: "{{ lookup('env', 'APIGEE_ORGANIZATION') }}"
     APIGEE_ACCESS_TOKEN: "{{ lookup('env', 'APIGEE_ACCESS_TOKEN') }}"
@@ -14,8 +15,15 @@
     apis_api_uri: "{{ organization_api_uri }}/apis"
     env_apis_api_uri: "{{ organization_api_uri}}/environments/{{ APIGEE_ENVIRONMENT }}/apis"
     apigee_uri: "https://{{ APIGEE_HOSTNAME }}"
+    environment_subdomain: "{{ APIGEE_ENVIRONMENT }}."
+    api_uri: "https://{{ (APIGEE_ENVIRONMENT != 'prod') | ternary(environment_subdomain, '') }}api.service.nhs.uk/{{ SERVICE_BASE_PATH }}"
 
   pre_tasks:
+    - name: check SERVICE_NAME
+      fail:
+        msg: "SERVICE_NAME not set"
+      when: not SERVICE_NAME
+
     - name: check SERVICE_NAME
       fail:
         msg: "SERVICE_NAME not set"

--- a/ansible/deploy-apigee-proxy.yml
+++ b/ansible/deploy-apigee-proxy.yml
@@ -24,10 +24,10 @@
         msg: "SERVICE_NAME not set"
       when: not SERVICE_NAME
 
-    - name: check SERVICE_NAME
+    - name: check SERVICE_BASE_PATH
       fail:
-        msg: "SERVICE_NAME not set"
-      when: not SERVICE_NAME
+        msg: "SERVICE_BASE_PATH not set"
+      when: not SERVICE_BASE_PATH
 
     - name: check APIGEE_ENVIRONMENT
       fail:

--- a/ansible/deploy-apigee-proxy.yml
+++ b/ansible/deploy-apigee-proxy.yml
@@ -1,0 +1,45 @@
+- name: "deploy apigee proxy"
+  hosts: 127.0.0.1
+  connection: local
+  gather_facts: yes
+
+  vars:
+    SERVICE_NAME: "{{ lookup('env', 'SERVICE_NAME') }}"
+    APIGEE_ENVIRONMENT: "{{ lookup('env','APIGEE_ENVIRONMENT') }}"
+    APIGEE_ORGANIZATION: "{{ lookup('env', 'APIGEE_ORGANIZATION') }}"
+    APIGEE_ACCESS_TOKEN: "{{ lookup('env', 'APIGEE_ACCESS_TOKEN') }}"
+    PROXY_DIR: "{{ lookup('env', 'PROXY_DIR') }}"
+    apigee_management_api_uri: "https://api.enterprise.apigee.com/v1"
+    organization_api_uri: "{{ apigee_management_api_uri }}/organizations/{{ APIGEE_ORGANIZATION }}"
+    apis_api_uri: "{{ organization_api_uri }}/apis"
+    env_apis_api_uri: "{{ organization_api_uri}}/environments/{{ APIGEE_ENVIRONMENT }}/apis"
+    apigee_uri: "https://{{ APIGEE_HOSTNAME }}"
+
+  pre_tasks:
+    - name: check SERVICE_NAME
+      fail:
+        msg: "SERVICE_NAME not set"
+      when: not SERVICE_NAME
+
+    - name: check APIGEE_ENVIRONMENT
+      fail:
+        msg: "APIGEE_ENVIRONMENT not set"
+      when: not APIGEE_ENVIRONMENT
+
+    - name: check APIGEE_ORGANIZATION
+      fail:
+        msg: "APIGEE_ORGANIZATION not set"
+      when: not APIGEE_ORGANIZATION
+
+    - name: check APIGEE_ACCESS_TOKEN
+      fail:
+        msg: "APIGEE_ACCESS_TOKEN not set"
+      when: not APIGEE_ACCESS_TOKEN
+
+    - name: check PROXY_DIR
+      fail:
+        msg: "PROXY_DIR not set"
+      when: not PROXY_DIR
+
+  roles:
+    - deploy-apigee-proxy

--- a/ansible/deploy-apigee-proxy.yml
+++ b/ansible/deploy-apigee-proxy.yml
@@ -10,13 +10,6 @@
     APIGEE_ORGANIZATION: "{{ lookup('env', 'APIGEE_ORGANIZATION') }}"
     APIGEE_ACCESS_TOKEN: "{{ lookup('env', 'APIGEE_ACCESS_TOKEN') }}"
     PROXY_DIR: "{{ lookup('env', 'PROXY_DIR') }}"
-    apigee_management_api_uri: "https://api.enterprise.apigee.com/v1"
-    organization_api_uri: "{{ apigee_management_api_uri }}/organizations/{{ APIGEE_ORGANIZATION }}"
-    apis_api_uri: "{{ organization_api_uri }}/apis"
-    env_apis_api_uri: "{{ organization_api_uri}}/environments/{{ APIGEE_ENVIRONMENT }}/apis"
-    apigee_uri: "https://{{ APIGEE_HOSTNAME }}"
-    environment_subdomain: "{{ APIGEE_ENVIRONMENT }}."
-    api_uri: "https://{{ (APIGEE_ENVIRONMENT != 'prod') | ternary(environment_subdomain, '') }}api.service.nhs.uk/{{ SERVICE_BASE_PATH }}"
 
   pre_tasks:
     - name: check SERVICE_NAME

--- a/ansible/roles/deploy-apigee-proxy/tasks/main.yml
+++ b/ansible/roles/deploy-apigee-proxy/tasks/main.yml
@@ -1,31 +1,29 @@
-- name: zip proxy directory
-  # Not using archive because we need the -X and -D options for it to produce the same hash every time
-  shell: "cd {{ PROXY_DIR }} && zip -rXD9 /tmp/proxy.zip apiproxy"
+# - name: zip proxy directory
+#   # Not using archive because we need the -X and -D options for it to produce the same hash every time
+#   shell: "cd {{ PROXY_DIR }} && zip -rXD9 /tmp/proxy.zip apiproxy"
 
-- name: calculate proxy zip hash
-  shell: "sha256sum /tmp/proxy.zip | cut -d' ' -f1"
-  register: "hash"
+# - name: calculate proxy zip hash
+#   shell: "sha512sum -b /tmp/proxy.zip | cut -d' ' -f1"
+#   register: "hash"
 
-- name: set proxy_hash
-  set_fact:
-    proxy_hash: "{{ hash.stdout }}"
+# - name: set proxy_hash
+#   set_fact:
+#     proxy_hash: "{{ hash.stdout }}"
 
-# NOTE: this is left here as a caution in case anyone else tries this. Apigee will give you errors with this.
-# Weirdly it's totally fine with curl.
-# - name: upload proxy bundle
-#   uri:
-#     url: "{{ apis_api_uri }}?action=import&name={{ SERVICE_NAME }}-{{ APIGEE_ENVIRONMENT }}"
-#     method: "POST"
-#     headers:
-#       Authorization: "Bearer {{ APIGEE_ACCESS_TOKEN }}"
-#       Content-Type: "multipart/form-data"
-#     src: "/tmp/proxy.zip"
-
+# NOTE: uri isn't used here because it exhibits some odd behaviour AND it doesn't return the request body
 - name: upload proxy bundle
   shell:
     cmd: "curl --fail -X POST -H 'Authorization: Bearer {{ APIGEE_ACCESS_TOKEN }}' -F 'file=@/tmp/proxy.zip' -H 'Content-Type: multipart/form-data' {{ apis_api_uri }}\\?action\\=import\\&name\\={{ SERVICE_NAME }}-{{ APIGEE_ENVIRONMENT }}"
     warn: false
   register: "proxy_upload_response"
+
+# - name: show uploaded proxy hash response
+#   debug:
+#     msg: "{{ (proxy_upload_response.stdout | from_json).manifestVersion }}"
+
+# - name: show hash we got
+#   debug:
+#     msg: "{{ proxy_hash }}"
 
 - name: get revision number of upload
   set_fact:
@@ -43,5 +41,20 @@
       Authorization: "Bearer {{ APIGEE_ACCESS_TOKEN }}"
     timeout: 300 # This needs to be quite long because the request will hang for at least as long as the delay
 
-- name: check deployed proxy is as expected
-  shell: "echo check deployed proxy is as expected"
+# NOTE: uri isn't used here because for some reason ansible's 'uri' module does not return the body of the request!
+# TODO: fix for prod
+# TODO: fix for when service basename is different from service name
+- name: ping deployed proxy
+  shell:
+    cmd: "curl https://{{ APIGEE_ENVIRONMENT }}.api.service.nhs.uk/{{ SERVICE_NAME }}/_ping"
+    warn: false
+  register: "proxy_ping_response"
+
+- name: set proxy_deployed_revision
+  set_fact:
+    proxy_deployed_revision: "{{ (proxy_ping_response.stdout | from_json).revision }}"
+
+- name: check correct revision was deployed
+  fail:
+    msg: "Incorrect revision {{ proxy_deployed_revision }}, was expecting {{ revision }}"
+  when: proxy_deployed_revision != revision

--- a/ansible/roles/deploy-apigee-proxy/tasks/main.yml
+++ b/ansible/roles/deploy-apigee-proxy/tasks/main.yml
@@ -1,0 +1,47 @@
+- name: zip proxy directory
+  # Not using archive because we need the -X and -D options for it to produce the same hash every time
+  shell: "cd {{ PROXY_DIR }} && zip -rXD9 /tmp/proxy.zip apiproxy"
+
+- name: calculate proxy zip hash
+  shell: "sha256sum /tmp/proxy.zip | cut -d' ' -f1"
+  register: "hash"
+
+- name: set proxy_hash
+  set_fact:
+    proxy_hash: "{{ hash.stdout }}"
+
+# NOTE: this is left here as a caution in case anyone else tries this. Apigee will give you errors with this.
+# Weirdly it's totally fine with curl.
+# - name: upload proxy bundle
+#   uri:
+#     url: "{{ apis_api_uri }}?action=import&name={{ SERVICE_NAME }}-{{ APIGEE_ENVIRONMENT }}"
+#     method: "POST"
+#     headers:
+#       Authorization: "Bearer {{ APIGEE_ACCESS_TOKEN }}"
+#       Content-Type: "multipart/form-data"
+#     src: "/tmp/proxy.zip"
+
+- name: upload proxy bundle
+  shell:
+    cmd: "curl --fail -X POST -H 'Authorization: Bearer {{ APIGEE_ACCESS_TOKEN }}' -F 'file=@/tmp/proxy.zip' -H 'Content-Type: multipart/form-data' {{ apis_api_uri }}\\?action\\=import\\&name\\={{ SERVICE_NAME }}-{{ APIGEE_ENVIRONMENT }}"
+    warn: false
+  register: "proxy_upload_response"
+
+- name: get revision number of upload
+  set_fact:
+    revision: "{{ (proxy_upload_response.stdout | from_json).revision }}"
+
+- name: update proxy deployment
+  uri:
+    url: "{{ env_apis_api_uri }}/{{ SERVICE_NAME }}-{{ APIGEE_ENVIRONMENT }}/revisions/{{ revision }}/deployments"
+    method: "POST"
+    body:
+      override: true
+      delay: 60
+    body_format: "form-urlencoded"
+    headers:
+      Authorization: "Bearer {{ APIGEE_ACCESS_TOKEN }}"
+    timeout: 300 # This needs to be quite long because the request will hang for at least as long as the delay
+
+- name: check deployed proxy is as expected
+  shell: "echo check deployed proxy is as expected"

--- a/ansible/roles/deploy-apigee-proxy/tasks/main.yml
+++ b/ansible/roles/deploy-apigee-proxy/tasks/main.yml
@@ -1,29 +1,9 @@
-# - name: zip proxy directory
-#   # Not using archive because we need the -X and -D options for it to produce the same hash every time
-#   shell: "cd {{ PROXY_DIR }} && zip -rXD9 /tmp/proxy.zip apiproxy"
-
-# - name: calculate proxy zip hash
-#   shell: "sha512sum -b /tmp/proxy.zip | cut -d' ' -f1"
-#   register: "hash"
-
-# - name: set proxy_hash
-#   set_fact:
-#     proxy_hash: "{{ hash.stdout }}"
-
 # NOTE: uri isn't used here because it exhibits some odd behaviour AND it doesn't return the request body
 - name: upload proxy bundle
   shell:
     cmd: "curl --fail -X POST -H 'Authorization: Bearer {{ APIGEE_ACCESS_TOKEN }}' -F 'file=@/tmp/proxy.zip' -H 'Content-Type: multipart/form-data' {{ apis_api_uri }}\\?action\\=import\\&name\\={{ SERVICE_NAME }}-{{ APIGEE_ENVIRONMENT }}"
     warn: false
   register: "proxy_upload_response"
-
-# - name: show uploaded proxy hash response
-#   debug:
-#     msg: "{{ (proxy_upload_response.stdout | from_json).manifestVersion }}"
-
-# - name: show hash we got
-#   debug:
-#     msg: "{{ proxy_hash }}"
 
 - name: get revision number of upload
   set_fact:

--- a/ansible/roles/deploy-apigee-proxy/tasks/main.yml
+++ b/ansible/roles/deploy-apigee-proxy/tasks/main.yml
@@ -42,8 +42,6 @@
     timeout: 300 # This needs to be quite long because the request will hang for at least as long as the delay
 
 # NOTE: uri isn't used here because for some reason ansible's 'uri' module does not return the body of the request!
-# TODO: fix for prod
-# TODO: fix for when service basename is different from service name
 - name: ping deployed proxy
   shell:
     cmd: "curl {{ api_uri }}/_ping"

--- a/ansible/roles/deploy-apigee-proxy/tasks/main.yml
+++ b/ansible/roles/deploy-apigee-proxy/tasks/main.yml
@@ -1,3 +1,7 @@
+- name: zip proxy directory
+  # Not using archive because we need the -X and -D options for it to produce the same hash every time
+  shell: "cd {{ PROXY_DIR }} && zip -rXD9 /tmp/proxy.zip apiproxy"
+
 # NOTE: uri isn't used here because it exhibits some odd behaviour AND it doesn't return the request body
 - name: upload proxy bundle
   shell:

--- a/ansible/roles/deploy-apigee-proxy/tasks/main.yml
+++ b/ansible/roles/deploy-apigee-proxy/tasks/main.yml
@@ -1,11 +1,16 @@
+- name: create a temp dir for zipping the proxy
+  tempfile:
+    state: directory
+  register: tempdir
+
 - name: zip proxy directory
   # Not using archive because we need the -X and -D options for it to produce the same hash every time
-  shell: "cd {{ PROXY_DIR }} && zip -rXD9 /tmp/proxy.zip apiproxy"
+  shell: "cd {{ PROXY_DIR }} && zip -rXD9 /{{ tempdir.path }}/proxy.zip apiproxy"
 
 # NOTE: uri isn't used here because it exhibits some odd behaviour AND it doesn't return the request body
 - name: upload proxy bundle
   shell:
-    cmd: "curl --fail -X POST -H 'Authorization: Bearer {{ APIGEE_ACCESS_TOKEN }}' -F 'file=@/tmp/proxy.zip' -H 'Content-Type: multipart/form-data' {{ apis_api_uri }}\\?action\\=import\\&name\\={{ SERVICE_NAME }}-{{ APIGEE_ENVIRONMENT }}"
+    cmd: "curl --fail -X POST -H 'Authorization: Bearer {{ APIGEE_ACCESS_TOKEN }}' -F 'file=@/{{ tempdir.path }}/proxy.zip' -H 'Content-Type: multipart/form-data' {{ apis_api_uri }}\\?action\\=import\\&name\\={{ SERVICE_NAME }}-{{ APIGEE_ENVIRONMENT }}"
     warn: false
   register: "proxy_upload_response"
 

--- a/ansible/roles/deploy-apigee-proxy/tasks/main.yml
+++ b/ansible/roles/deploy-apigee-proxy/tasks/main.yml
@@ -46,7 +46,7 @@
 # TODO: fix for when service basename is different from service name
 - name: ping deployed proxy
   shell:
-    cmd: "curl https://{{ APIGEE_ENVIRONMENT }}.api.service.nhs.uk/{{ SERVICE_NAME }}/_ping"
+    cmd: "curl {{ api_uri }}/_ping"
     warn: false
   register: "proxy_ping_response"
 

--- a/ansible/roles/deploy-apigee-proxy/vars/main.yml
+++ b/ansible/roles/deploy-apigee-proxy/vars/main.yml
@@ -1,0 +1,7 @@
+apigee_management_api_uri: "https://api.enterprise.apigee.com/v1"
+organization_api_uri: "{{ apigee_management_api_uri }}/organizations/{{ APIGEE_ORGANIZATION }}"
+apis_api_uri: "{{ organization_api_uri }}/apis"
+env_apis_api_uri: "{{ organization_api_uri}}/environments/{{ APIGEE_ENVIRONMENT }}/apis"
+apigee_uri: "https://{{ APIGEE_HOSTNAME }}"
+environment_subdomain: "{{ APIGEE_ENVIRONMENT }}."
+api_uri: "https://{{ (APIGEE_ENVIRONMENT != 'prod') | ternary(environment_subdomain, '') }}api.service.nhs.uk/{{ SERVICE_BASE_PATH }}"


### PR DESCRIPTION
This change is a dumb deploy of proxies and the new proxy revisions they create; by that, I mean that if the same proxy is already deployed, it will be written over regardless. I'll split that improvement out into a new ticket to take up later.

This will replace part of the terrraform currently in use in the deploy-service task. Ideally we will want to replace all of it at some point, so I will create another ticket for that work.