### PR TITLE
APM-1100 Allow skipping _ping step and fail if a ping fails

### DIFF
--- a/ansible/deploy-apigee-proxy.yml
+++ b/ansible/deploy-apigee-proxy.yml
@@ -10,7 +10,7 @@
     APIGEE_ORGANIZATION: "{{ lookup('env', 'APIGEE_ORGANIZATION') }}"
     APIGEE_ACCESS_TOKEN: "{{ lookup('env', 'APIGEE_ACCESS_TOKEN') }}"
     PROXY_DIR: "{{ lookup('env', 'PROXY_DIR') }}"
-    NO_PING: "{{ lookup('env', 'NO_PING') }}"
+    NO_PING: "{{ (lookup('env', 'NO_PING') | length > 0) | ternary(lookup('env', 'NO_PING'), 'true') }}"
 
   pre_tasks:
     - name: check SERVICE_NAME
@@ -42,6 +42,10 @@
       fail:
         msg: "PROXY_DIR not set"
       when: not PROXY_DIR
+
+    - name: show NO_PING
+      debug:
+        var: NO_PING
 
   roles:
     - deploy-apigee-proxy

--- a/ansible/deploy-apigee-proxy.yml
+++ b/ansible/deploy-apigee-proxy.yml
@@ -10,6 +10,7 @@
     APIGEE_ORGANIZATION: "{{ lookup('env', 'APIGEE_ORGANIZATION') }}"
     APIGEE_ACCESS_TOKEN: "{{ lookup('env', 'APIGEE_ACCESS_TOKEN') }}"
     PROXY_DIR: "{{ lookup('env', 'PROXY_DIR') }}"
+    NO_PING: "{{ lookup('env', 'NO_PING') }}"
 
   pre_tasks:
     - name: check SERVICE_NAME

--- a/ansible/roles/deploy-apigee-proxy/tasks/main.yml
+++ b/ansible/roles/deploy-apigee-proxy/tasks/main.yml
@@ -36,14 +36,14 @@
     cmd: "curl --fail {{ api_uri }}/_ping"
     warn: false
   register: "proxy_ping_response"
-  when: not NO_PING
+  when: NO_PING != "true"
 
 - name: set proxy_deployed_revision
   set_fact:
     proxy_deployed_revision: "{{ (proxy_ping_response.stdout | from_json).revision }}"
-  when: not NO_PING
+  when: NO_PING != "true"
 
 - name: check correct revision was deployed
   fail:
     msg: "Incorrect revision {{ proxy_deployed_revision }}, was expecting {{ revision }}"
-  when: not NO_PING and proxy_deployed_revision != revision
+  when: NO_PING != "true" and proxy_deployed_revision != revision

--- a/ansible/roles/deploy-apigee-proxy/tasks/main.yml
+++ b/ansible/roles/deploy-apigee-proxy/tasks/main.yml
@@ -33,15 +33,17 @@
 # NOTE: uri isn't used here because for some reason ansible's 'uri' module does not return the body of the request!
 - name: ping deployed proxy
   shell:
-    cmd: "curl {{ api_uri }}/_ping"
+    cmd: "curl --fail {{ api_uri }}/_ping"
     warn: false
   register: "proxy_ping_response"
+  when: not NO_PING
 
 - name: set proxy_deployed_revision
   set_fact:
     proxy_deployed_revision: "{{ (proxy_ping_response.stdout | from_json).revision }}"
+  when: not NO_PING
 
 - name: check correct revision was deployed
   fail:
     msg: "Incorrect revision {{ proxy_deployed_revision }}, was expecting {{ revision }}"
-  when: proxy_deployed_revision != revision
+  when: not NO_PING and proxy_deployed_revision != revision


### PR DESCRIPTION
Some proxies don't have ping yet, and the deploy was dying with an unhelpful error: https://dev.azure.com/NHSD-APIM/API%20Platform/_releaseProgress?_a=release-environment-logs&releaseId=2328&environmentId=8629