### PR TITLE
APM-1162 Re-add reporting to github for PRs

### DIFF
--- a/azure/common/deploy-stage.yml
+++ b/azure/common/deploy-stage.yml
@@ -34,6 +34,9 @@ parameters:
     type: stepList
   - name: post_deploy
     type: stepList
+  - name: notify
+    type: boolean
+    default: false
 
 stages:
   - stage: ${{ parameters.stage_name }}
@@ -56,6 +59,11 @@ stages:
                     runVersion: "latestFromBranch"
                     runBranch: $(Build.SourceBranch)
                     path: "$(Pipeline.Workspace)/s/${{ parameters.service_name }}"
+
+                - bash: |
+                    echo $(Build.SourceVersion)
+                    echo $(Build.SourceVersionMessage)
+                    echo $(resources.pipeline.build_pipeline.sourceCommit)
 
                 - task: DownloadSecureFile@1
                   name: aws_config
@@ -97,6 +105,7 @@ stages:
 
                 - template: "../templates/deploy-service.yml"
                   parameters:
+                    notify: ${{ parameters.notify }}
                     service_name: ${{ parameters.service_name }}
                     short_service_name: ${{ parameters.short_service_name }}
                     fully_qualified_service_name: ${{ parameters.fully_qualified_service_name }}

--- a/azure/common/pr.yml
+++ b/azure/common/pr.yml
@@ -34,6 +34,7 @@ parameters:
 stages:
   - template: ./deploy-stage.yml
     parameters:
+      notify: true
       fully_qualified_service_name: ${{ parameters.service_name }}-pr-${{ replace(replace(replace(variables['Build.SourceBranch'], '/merge', ''), 'refs/pull/', ''), '/', '_') }}
       service_base_path: ${{ parameters.service_base_path }}-pr-${{ replace(replace(replace(variables['Build.SourceBranch'], '/merge', ''), 'refs/pull/', ''), '/', '_') }}
       ${{ each param in parameters }}:

--- a/azure/components/update-github-status.yml
+++ b/azure/components/update-github-status.yml
@@ -23,8 +23,8 @@ parameters:
 
 steps:
   - bash: |
-      curl --fail -q -X POST "https://api.github.com/repos/$(Build.Repository.Name)/statuses/$(Build.SourceVersion)" -d '{"state": "${{ parameters.state }}", "context": "$(Build.DefinitionName)", "description": "${{ parameters.description }}", "target_url": "https://dev.azure.com/NHSD-APIM/API%20Platform/_build/results?buildId=$(Build.BuildID)"}' --user $(GITHUB_USER):$(GITHUB_ACCESS_TOKEN)
-    displayName: "Notify GitHub that the pipeline has started"
+      curl --fail -q -X POST "https://api.github.com/repos/$(Build.Repository.Name)/statuses/$(COMMIT_SHA)" -d '{"state": "${{ parameters.state }}", "context": "$(Build.DefinitionName)", "description": "${{ parameters.description }}", "target_url": "https://dev.azure.com/NHSD-APIM/API%20Platform/_build/results?buildId=$(Build.BuildID)"}' --user $(GITHUB_USER):$(GITHUB_ACCESS_TOKEN)
+    displayName: "Notify GitHub: ${{ parameters.state }}"
     condition: |
       or(
         and(

--- a/azure/templates/deploy-service.yml
+++ b/azure/templates/deploy-service.yml
@@ -1,4 +1,6 @@
 parameters:
+  - name: notify
+    type: boolean
   - name: proxy_path
   - name: product_display_name
   - name: product_description
@@ -22,6 +24,17 @@ parameters:
     default: []
 
 steps:
+  - ${{ if parameters.notify }}:
+      - bash: |
+          export COMMIT_SHA=`echo $(Build.SourceVersionMessage) | cut -d' ' -f2`
+          echo "##vso[task.setvariable variable=COMMIT_SHA]$COMMIT_SHA"
+        displayName: Set COMMIT_SHA
+
+      - template: '../components/update-github-status.yml'
+        parameters:
+          state: pending
+          description: "Deploy to ${{ parameters.apigee_environment }} started"
+
   - bash: |
       ls -R
       if [[ -f ecs-proxies-deploy.yml ]]; then
@@ -126,3 +139,16 @@ steps:
 
   - ${{ each post_deploy_step in parameters.post_deploy }}:
     - ${{ post_deploy_step}}
+
+  - ${{ if parameters.notify }}:
+      - template: '../components/update-github-status.yml'
+        parameters:
+          state: success
+          on_success: true
+          description: "Deploy to ${{ parameters.apigee_environment }} started"
+
+      - template: '../components/update-github-status.yml'
+        parameters:
+          state: failure
+          on_failure: true
+          description: "Deploy to ${{ parameters.apigee_environment }} started"


### PR DESCRIPTION
Adds:
* `notify` flag to toggle github notifying behaviour
* Fetching `COMMIT_SHA` by parsing it from `$(Build.SourceVersionMessage)` [0]
* Changes the github notify template to use `COMMIT_SHA` instead of `$(Build.SourceVersion)` [0]
* Change the `displayName` of the github notify template to make more sense

[0] This has to be done because `$(Build.SourceVersion)` is the commit hash of the _merge commit_, i.e. the commit that will be created when the branch is merged. GitHub status reporting uses the commit hash of the top commit of a branch, or the `head`. Azure pipeline does not provide an easy way to access this head commit hash value, but it is included in the `$(Build.SourceVersionMessage)`, which takes the form of `Merge abc in to xyz` -- and we want `abc`.