### PR TITLE
AMB-229 add "Add monitoring endpoints" step to the deploy-service.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,5 @@ dmypy.json
 .envrc
 .direnv
 env
+
+.DS_Store

--- a/ansible/roles/deploy-apigee-proxy/tasks/main.yml
+++ b/ansible/roles/deploy-apigee-proxy/tasks/main.yml
@@ -54,3 +54,14 @@
   fail:
     msg: "Incorrect revision {{ proxy_deployed_revision }}, was expecting {{ revision }}"
   when: NO_PING != "true" and proxy_deployed_revision != revision
+
+- name: Add monitoring endpoint
+  uri:
+    url: "https://internal-dev.api.service.nhs.uk/monitoring-sd/service"
+    method: "POST"
+    headers:
+      apikey: "{{ MONITORING_API_KEY }}"
+    body: "{{ monitoring_body }}"
+    body_format: "json"
+    retries: 3
+

--- a/ansible/roles/deploy-apigee-proxy/tasks/main.yml
+++ b/ansible/roles/deploy-apigee-proxy/tasks/main.yml
@@ -64,4 +64,5 @@
     body: "{{ monitoring_body }}"
     body_format: "json"
     retries: 3
+  when: ADD_MONITORING == "true"
 

--- a/ansible/roles/deploy-apigee-proxy/tasks/main.yml
+++ b/ansible/roles/deploy-apigee-proxy/tasks/main.yml
@@ -55,7 +55,7 @@
     msg: "Incorrect revision {{ proxy_deployed_revision }}, was expecting {{ revision }}"
   when: NO_PING != "true" and proxy_deployed_revision != revision
 
-- name: Add monitoring endpoint
+- name: add monitoring endpoint
   uri:
     url: "https://internal-dev.api.service.nhs.uk/monitoring-sd/service"
     method: "POST"

--- a/ansible/roles/deploy-apigee-proxy/vars/main.yml
+++ b/ansible/roles/deploy-apigee-proxy/vars/main.yml
@@ -5,3 +5,6 @@ env_apis_api_uri: "{{ organization_api_uri}}/environments/{{ APIGEE_ENVIRONMENT 
 apigee_uri: "https://{{ APIGEE_HOSTNAME }}"
 environment_subdomain: "{{ APIGEE_ENVIRONMENT }}."
 api_uri: "https://{{ (APIGEE_ENVIRONMENT != 'prod') | ternary(environment_subdomain, '') }}api.service.nhs.uk/{{ SERVICE_BASE_PATH }}"
+MONITORING_API_KEY: "{{ lookup('env', 'MONITORING_API_KEY') }}"
+monitoring_endpoints: "[\"{{ api_uri/_ping }}\"]"
+monitoring_body: "{\"{{ SERVICE_NAME }}\": {\"{{ APIGEE_ENVIRONMENT }}\": {{ monitoring_endpoints }} }}"

--- a/ansible/roles/deploy-apigee-proxy/vars/main.yml
+++ b/ansible/roles/deploy-apigee-proxy/vars/main.yml
@@ -5,6 +5,7 @@ env_apis_api_uri: "{{ organization_api_uri}}/environments/{{ APIGEE_ENVIRONMENT 
 apigee_uri: "https://{{ APIGEE_HOSTNAME }}"
 environment_subdomain: "{{ APIGEE_ENVIRONMENT }}."
 api_uri: "https://{{ (APIGEE_ENVIRONMENT != 'prod') | ternary(environment_subdomain, '') }}api.service.nhs.uk/{{ SERVICE_BASE_PATH }}"
+ADD_MONITORING: "{{ lookup('env', 'ADD_MONITORING') }}"
 MONITORING_API_KEY: "{{ lookup('env', 'MONITORING_API_KEY') }}"
 monitoring_endpoints: "[\"{{ api_uri/_ping }}\"]"
 monitoring_body: "{\"{{ SERVICE_NAME }}\": {\"{{ APIGEE_ENVIRONMENT }}\": {{ monitoring_endpoints }} }}"

--- a/azure/common/deploy-stage.yml
+++ b/azure/common/deploy-stage.yml
@@ -51,7 +51,7 @@ stages:
             deploy:
               steps:
                 - download: none
-                  
+
                 - task: DownloadPipelineArtifact@2
                   inputs:
                     source: "specific"
@@ -95,6 +95,7 @@ stages:
                       - ${{ parameters.aws_org_account }}/azure-devops/apigee-${{ parameters.apigee_organization }}/APIGEE_OTP_KEY
                       - ${{ parameters.aws_org_account }}/azure-devops/apigee-${{ parameters.apigee_organization }}/APIGEE_PASSWORD
                       - ptl/access-tokens/github/repo-status-update/GITHUB_ACCESS_TOKEN
+                      - ${{ parameters.aws_org_account }}/azure-devops/MONITORING_API_KEY
                       - ${{ each secret_id in parameters.secret_ids }}:
                           - ${{ secret_id }}
                     config_ids:

--- a/azure/templates/deploy-service.yml
+++ b/azure/templates/deploy-service.yml
@@ -5,6 +5,7 @@ parameters:
   - name: product_display_name
   - name: product_description
   - name: service_name
+  - name: api_key
   - name: short_service_name
   - name: fully_qualified_service_name
   - name: apigee_environment
@@ -146,6 +147,12 @@ steps:
       poetry run ansible-playbook deploy-apigee-proxy.yml
       poetry run ansible-playbook deploy-apigee-product.yml
     displayName: 'Deploy Proxy and Product'
+  - bash: |
+      set -euo pipefail
+
+      export PING="${{ parameters.service_name }}@${{ parameters.apigee_environment }}=http_2xx https://${{ parameters.apigee_environment }}.api.service.nhs.uk${{ parameters.service_base_path }}/_ping"
+      curl -X POST -H "apikey: ${{ parameters.api_key }}" "https://${{ parameters.apigee_environment }}.api.service.nhs.uk/monitoring-sd/service" -d "{\"${{ parameters.service_name }}\": {\"${{ parameters.apigee_environment }}\": [\"${PING}\"]}}"
+    displayName: Add monitoring endpoints
 
   - ${{ each post_deploy_step in parameters.post_deploy }}:
     - ${{ post_deploy_step}}

--- a/azure/templates/deploy-service.yml
+++ b/azure/templates/deploy-service.yml
@@ -5,7 +5,6 @@ parameters:
   - name: product_display_name
   - name: product_description
   - name: service_name
-  - name: api_key
   - name: short_service_name
   - name: fully_qualified_service_name
   - name: apigee_environment
@@ -147,12 +146,6 @@ steps:
       poetry run ansible-playbook deploy-apigee-proxy.yml
       poetry run ansible-playbook deploy-apigee-product.yml
     displayName: 'Deploy Proxy and Product'
-  - bash: |
-      set -euo pipefail
-
-      export PING="${{ parameters.service_name }}@${{ parameters.apigee_environment }}=http_2xx https://${{ parameters.apigee_environment }}.api.service.nhs.uk${{ parameters.service_base_path }}/_ping"
-      curl -X POST -H "apikey: ${{ parameters.api_key }}" "https://internal-dev.api.service.nhs.uk/monitoring-sd/service" -d "{\"${{ parameters.service_name }}\": {\"${{ parameters.apigee_environment }}\": [\"${PING}\"]}}"
-    displayName: Add monitoring endpoints
 
   - ${{ each post_deploy_step in parameters.post_deploy }}:
     - ${{ post_deploy_step}}

--- a/azure/templates/deploy-service.yml
+++ b/azure/templates/deploy-service.yml
@@ -151,7 +151,7 @@ steps:
       set -euo pipefail
 
       export PING="${{ parameters.service_name }}@${{ parameters.apigee_environment }}=http_2xx https://${{ parameters.apigee_environment }}.api.service.nhs.uk${{ parameters.service_base_path }}/_ping"
-      curl -X POST -H "apikey: ${{ parameters.api_key }}" "https://${{ parameters.apigee_environment }}.api.service.nhs.uk/monitoring-sd/service" -d "{\"${{ parameters.service_name }}\": {\"${{ parameters.apigee_environment }}\": [\"${PING}\"]}}"
+      curl -X POST -H "apikey: ${{ parameters.api_key }}" "https://internal-dev.api.service.nhs.uk/monitoring-sd/service" -d "{\"${{ parameters.service_name }}\": {\"${{ parameters.apigee_environment }}\": [\"${PING}\"]}}"
     displayName: Add monitoring endpoints
 
   - ${{ each post_deploy_step in parameters.post_deploy }}:


### PR DESCRIPTION
This step will post a monitoring url (currently only `_ping`) to the monitoring service discovery. 
~Adding this step only works for `internal-dev` and for other environment curl command will fail because at the moment that service-discovery only exists for `internal-dev`~