### PR TITLE
APM-1356 Use 'common' resource everywhere we need utils and place utils in the build artifact

### DIFF
--- a/ansible/roles/deploy-apigee-proxy/tasks/main.yml
+++ b/ansible/roles/deploy-apigee-proxy/tasks/main.yml
@@ -43,14 +43,14 @@
     url: "{{ api_uri }}/_ping"
     return_content: yes
   register: proxy_ping_response
-  when: PING != "false"
+  when: PING
 
 - name: set proxy_deployed_revision
   set_fact:
     proxy_deployed_revision: "{{ (proxy_ping_response.content | from_json).revision }}"
-  when: PING != "false"
+  when: PING
 
 - name: check correct revision was deployed
   fail:
     msg: "Incorrect revision {{ proxy_deployed_revision }}, was expecting {{ revision }}"
-  when: PING != "false" and proxy_deployed_revision != revision
+  when: PING and proxy_deployed_revision != revision

--- a/azure/common/apigee-build.yml
+++ b/azure/common/apigee-build.yml
@@ -10,13 +10,6 @@ parameters:
     type: stepList
     default: []
 
-resources:
-  repositories:
-    - repository: utils
-      name: NHSDigital/api-management-utils
-      endpoint: NHSDigital
-      type: github
-
 jobs:
   - job: build
     displayName: Build & Test
@@ -93,7 +86,7 @@ jobs:
         workingDirectory: ${{ parameters.service_name }}
         displayName: "Check for ECS proxy definitions"
 
-      - checkout: utils
+      - checkout: common
         path: "s/${{ parameters.service_name }}/utils"
 
       - bash: "make install"

--- a/azure/common/apigee-build.yml
+++ b/azure/common/apigee-build.yml
@@ -95,7 +95,6 @@ jobs:
 
       - checkout: utils
         path: "s/${{ parameters.service_name }}/utils"
-        condition: and(succeeded(), eq(variables['build_containers'], 'true'))
 
       - bash: "make install"
         workingDirectory: "${{ parameters.service_name }}/utils"

--- a/azure/common/apigee-build.yml
+++ b/azure/common/apigee-build.yml
@@ -148,5 +148,9 @@ jobs:
         displayName: "Copy ecs-proxies-deploy configs into build artifact"
         condition: and(succeeded(), eq(variables['build_containers'], 'true'))
 
+      - bash: |
+          cp -R utils dist/utils
+        displayName: "Copy utils into artifact"
+
       - publish: ${{ parameters.service_name}}/dist
         artifact: "$(Build.BuildNumber)"

--- a/azure/common/apigee-build.yml
+++ b/azure/common/apigee-build.yml
@@ -149,6 +149,7 @@ jobs:
 
       - bash: |
           cp -R utils dist/utils
+        workingDirectory: "${{ parameters.service_name }}"
         displayName: "Copy utils into artifact"
 
       - publish: ${{ parameters.service_name}}/dist

--- a/azure/common/deploy-stage.yml
+++ b/azure/common/deploy-stage.yml
@@ -132,10 +132,6 @@ stages:
                       apigee_environment: ${{ parameters.environment }}
                       fully_qualified_service_name: ${{ parameters.fully_qualified_service_name }}
                 
-                - template: "../components/clone-utils.yml" 
-                  parameters:
-                    service_name: ${{ parameters.service_name }}
-
                 - template: "../templates/deploy-service.yml"
                   parameters:
                     service_name: ${{ parameters.service_name }}

--- a/azure/templates/deploy-service.yml
+++ b/azure/templates/deploy-service.yml
@@ -32,12 +32,6 @@ steps:
     workingDirectory: ${{ parameters.service_name }}/$(SERVICE_ARTIFACT_NAME)
     displayName: "Check for ECS proxy definitions"
 
-  - bash: |
-      git clone https://github.com/NHSDigital/api-management-utils.git $(Pipeline.Workspace)/s/${{ parameters.service_name }}/$(SERVICE_ARTIFACT_NAME)/utils
-      git checkout ${{ resources.repositories.common.ref }}
-      cd $(Pipeline.Workspace)/s/${{ parameters.service_name }}/$(SERVICE_ARTIFACT_NAME)/utils
-    displayName: Clone utils
-
   - bash: "make install"
     workingDirectory: "$(Pipeline.Workspace)/s/${{ parameters.service_name }}/$(SERVICE_ARTIFACT_NAME)/utils"
     displayName: "Install utils pre-requisites"

--- a/azure/templates/deploy-service.yml
+++ b/azure/templates/deploy-service.yml
@@ -34,6 +34,7 @@ steps:
 
   - bash: |
       git clone https://github.com/NHSDigital/api-management-utils.git $(Pipeline.Workspace)/s/${{ parameters.service_name }}/$(SERVICE_ARTIFACT_NAME)/utils
+      git checkout ${{ resources.repositories.common.ref }}
       cd $(Pipeline.Workspace)/s/${{ parameters.service_name }}/$(SERVICE_ARTIFACT_NAME)/utils
     displayName: Clone utils
 


### PR DESCRIPTION
* Uses only the 'common' utils resource (all explicit clones have been removed and all non-common utils clones have been taken out)
* Utils is copied into the build artifact near the end of the build
* Utils is then used directly from the artifact in prs and releases
* Fixed the PING condition in the proxy deploy ⚠️ this may cause some deploys where a ping is NOT desired to fail. It should not affect deploys where a ping is desired.