### PR TITLE
APM-1162 Don't copy accross .venv

### DIFF
--- a/azure/common/apigee-build.yml
+++ b/azure/common/apigee-build.yml
@@ -141,7 +141,7 @@ jobs:
         condition: and(succeeded(), eq(variables['build_containers'], 'true'))
 
       - bash: |
-          cp -R utils dist/utils
+          rsync -a utils dist --exclude .venv
         workingDirectory: "${{ parameters.service_name }}"
         displayName: "Copy utils into artifact"
 


### PR DESCRIPTION
* Doesn't copy across .venv when copying utils into the artifact, preventing a issue in deploys