### PR TITLE
APM-00-AMB-266 retrieve JWT_PRIVATE_KEY from secret manager

### DIFF
--- a/azure/common/deploy-stage.yml
+++ b/azure/common/deploy-stage.yml
@@ -118,7 +118,6 @@ stages:
                       - ${{ parameters.aws_org_account }}/azure-devops/apigee-${{ parameters.apigee_organization }}/APIGEE_OTP_KEY
                       - ${{ parameters.aws_org_account }}/azure-devops/apigee-${{ parameters.apigee_organization }}/APIGEE_PASSWORD
                       - ${{ parameters.aws_org_account }}/azure-devops/MONITORING_API_KEY
-                      - ${{ parameters.aws_org_account }}/azure-devops/${{ parameters.service_name }}/${{ parameters.environment }}/JWT_PRIVATE_KEY
                       - ptl/access-tokens/github/repo-status-update/GITHUB_ACCESS_TOKEN
                       - ${{ each secret_id in parameters.secret_ids }}:
                           - ${{ secret_id }}

--- a/azure/common/deploy-stage.yml
+++ b/azure/common/deploy-stage.yml
@@ -118,6 +118,7 @@ stages:
                       - ${{ parameters.aws_org_account }}/azure-devops/apigee-${{ parameters.apigee_organization }}/APIGEE_OTP_KEY
                       - ${{ parameters.aws_org_account }}/azure-devops/apigee-${{ parameters.apigee_organization }}/APIGEE_PASSWORD
                       - ${{ parameters.aws_org_account }}/azure-devops/MONITORING_API_KEY
+                      - ${{ parameters.aws_org_account }}/azure-devops/${{ parameters.service_name }}/${{ parameters.environment }}/JWT_PRIVATE_KEY
                       - ptl/access-tokens/github/repo-status-update/GITHUB_ACCESS_TOKEN
                       - ${{ each secret_id in parameters.secret_ids }}:
                           - ${{ secret_id }}

--- a/azure/components/get-aws-secrets-and-ssm-params.yml
+++ b/azure/components/get-aws-secrets-and-ssm-params.yml
@@ -9,7 +9,7 @@ steps:
     - bash: |
         set -euo pipefail
         secret_name=$(expr match ${{ secret_id }} '.*/\(.*\)')
-        secret_value=$(aws --profile apm_ptl secretsmanager get-secret-value --secret-id ${{ secret_id }} --query SecretString --output text)
+        secret_value=$(aws --profile apm_ptl secretsmanager get-secret-value --secret-id ${{ secret_id }} --query SecretString --output text) || 'UNKNOWN'
         echo "##vso[task.setvariable variable=${secret_name};issecret=true]${secret_value}"
       displayName: 'Get secret ${{ secret_id }}'
 

--- a/azure/components/get-aws-secrets-and-ssm-params.yml
+++ b/azure/components/get-aws-secrets-and-ssm-params.yml
@@ -9,13 +9,7 @@ steps:
     - bash: |
         set -euo pipefail
         secret_name=$(expr match ${{ secret_id }} '.*/\(.*\)')
-        cmd="aws --profile apm_ptl secretsmanager get-secret-value --secret-id ${{ secret_id }} --query SecretString --output text"
-        if secret_value=$($cmd) ; then
-        	echo "Secret ${secret_name} retreived successfully"
-        else
-        	secret_value="UNKNOWN"
-        	echo "WARNING: Failed to retreived secret: ${secret_name}"
-        fi
+        secret_value=$(aws --profile apm_ptl secretsmanager get-secret-value --secret-id ${{ secret_id }} --query SecretString --output text)
 
         echo "##vso[task.setvariable variable=${secret_name};issecret=true]${secret_value}"
       displayName: 'Get secret ${{ secret_id }}'

--- a/azure/components/get-aws-secrets-and-ssm-params.yml
+++ b/azure/components/get-aws-secrets-and-ssm-params.yml
@@ -9,7 +9,14 @@ steps:
     - bash: |
         set -euo pipefail
         secret_name=$(expr match ${{ secret_id }} '.*/\(.*\)')
-        secret_value=$(aws --profile apm_ptl secretsmanager get-secret-value --secret-id ${{ secret_id }} --query SecretString --output text) || 'UNKNOWN'
+        cmd="aws --profile apm_ptl secretsmanager get-secret-value --secret-id ${{ secret_id }} --query SecretString --output text"
+        if secret_value=$($cmd) ; then
+        	echo "Secret ${secret_value} retreived successfully"
+        else
+        	secret_value="UNKNOWN"
+        	echo "WARNING: Failed to retreived secret: ${secret_name}"
+        fi
+
         echo "##vso[task.setvariable variable=${secret_name};issecret=true]${secret_value}"
       displayName: 'Get secret ${{ secret_id }}'
 

--- a/azure/components/get-aws-secrets-and-ssm-params.yml
+++ b/azure/components/get-aws-secrets-and-ssm-params.yml
@@ -11,7 +11,7 @@ steps:
         secret_name=$(expr match ${{ secret_id }} '.*/\(.*\)')
         cmd="aws --profile apm_ptl secretsmanager get-secret-value --secret-id ${{ secret_id }} --query SecretString --output text"
         if secret_value=$($cmd) ; then
-        	echo "Secret ${secret_value} retreived successfully"
+        	echo "Secret ${secret_name} retreived successfully"
         else
         	secret_value="UNKNOWN"
         	echo "WARNING: Failed to retreived secret: ${secret_name}"


### PR DESCRIPTION
For running unattended access postman tests we need access to the private key. This key should be namespaced based on `service_name` and `environment`.
[ticket AMB-266](https://nhsd-jira.digital.nhs.uk/browse/AMB-266)