### PR TITLE
APM-1162 Enable build notifications by default

### DIFF
--- a/azure/common/apigee-build.yml
+++ b/azure/common/apigee-build.yml
@@ -14,7 +14,7 @@ parameters:
     default: []
   - name: notify
     type: boolean
-    default: false
+    default: true
 
 jobs:
   - job: build


### PR DESCRIPTION
This is possible now because of a change to the common 'update github status' step, which now will warn instead of fail when the COMMIT_HASH is not properly set.

It appears that azure devops has totally given up on trying to give us status updates anymore, so this change is required to get this working again.