### PR TITLE
APM-1162 Dump utils pipeline version in artifact

### DIFF
--- a/azure/common/apigee-build.yml
+++ b/azure/common/apigee-build.yml
@@ -185,6 +185,10 @@ jobs:
         workingDirectory: "${{ parameters.service_name }}"
         displayName: "Copy utils into artifact"
 
+      - bash: |
+          cd ${{ parameters.service_name }}/utils
+          git rev-parse HEAD > ../dist/.utils-version
+
       - publish: ${{ parameters.service_name}}/dist
         artifact: "$(Build.BuildNumber)"
 


### PR DESCRIPTION
This is for possible future changes -- adding utils version so we can either enforce match or use matching version.