### PR TITLE
APM-1694 Use service name on PR's as product names

### DIFF
--- a/ansible/roles/deploy-apigee-product-and-spec/tasks/deploy-product-and-apidoc.yml
+++ b/ansible/roles/deploy-apigee-product-and-spec/tasks/deploy-product-and-apidoc.yml
@@ -30,7 +30,7 @@
                                      SERVICE_NAME)
         }}
       qualified_display_name: >-
-        {{ product.displayName }} ({{ env_names[APIGEE_ENVIRONMENT] }} Environment)
+        {{ ('-pr-' in SERVICE_NAME) | ternary(qualified_product_name, product.displayName) }} ({{ env_names[APIGEE_ENVIRONMENT] }} Environment)
     set_fact:
       product: >-
         {{ product | combine({'displayName': qualified_display_name,

--- a/ansible/roles/deploy-apigee-product-and-spec/tasks/main.yml
+++ b/ansible/roles/deploy-apigee-product-and-spec/tasks/main.yml
@@ -104,7 +104,7 @@
     set_fact:
       default_product:
         name: "" # SERVICE_NAME is appended inside loop, so leave blank here
-        displayName: "{{ ('-pr-' in SERVICE_NAME) | ternary(SERVICE_NAME, PRODUCT_DISPLAY_NAME) }}" # Environment name appended later
+        displayName: "{{ PRODUCT_DISPLAY_NAME }}" # Environment name appended later
         description: "{{ PRODUCT_DESCRIPTION }}"
         approvalType: "{{ approval_type }}"
         proxies: "{{ proxies }}"

--- a/ansible/roles/deploy-apigee-product-and-spec/tasks/main.yml
+++ b/ansible/roles/deploy-apigee-product-and-spec/tasks/main.yml
@@ -120,9 +120,6 @@
           - "{{ APIGEE_ENVIRONMENT }}"
         scopes: []
 
-  - debug:
-      msg: "{{ default_product }}"
-
   - name: List product files
     set_fact:
       # we are in dist/utils/ansible

--- a/ansible/roles/deploy-apigee-product-and-spec/tasks/main.yml
+++ b/ansible/roles/deploy-apigee-product-and-spec/tasks/main.yml
@@ -104,7 +104,7 @@
     set_fact:
       default_product:
         name: "" # SERVICE_NAME is appended inside loop, so leave blank here
-        displayName: "{{ PRODUCT_DISPLAY_NAME }}" # Environment name appended later
+        displayName: "{{ ('-pr-' in SERVICE_NAME) | ternary(SERVICE_NAME, PRODUCT_DISPLAY_NAME) }}" # Environment name appended later
         description: "{{ PRODUCT_DESCRIPTION }}"
         approvalType: "{{ approval_type }}"
         proxies: "{{ proxies }}"
@@ -119,6 +119,9 @@
         environments:
           - "{{ APIGEE_ENVIRONMENT }}"
         scopes: []
+
+  - debug:
+      msg: "{{ default_product }}"
 
   - name: List product files
     set_fact:


### PR DESCRIPTION
* Use service instead of product name on pull requests, so its easier to determine PR products from release