### PR TITLE
APM-1162 Fix auto-enrolment to monitoring for production services

### DIFF
--- a/azure/components/curl.yml
+++ b/azure/components/curl.yml
@@ -14,5 +14,5 @@ parameters:
 
 steps:
   - bash: |
-      curl -X '${{ parameters.method }}' -H '${{ parameters.headers }}' -d '${{ parameters.body }}' '${{ parameters.url }}'
+      curl --fail -X '${{ parameters.method }}' -H '${{ parameters.headers }}' -d '${{ parameters.body }}' '${{ parameters.url }}'
     displayName: ${{ coalesce(parameters.display_name, 'curl') }}

--- a/azure/templates/deploy-service.yml
+++ b/azure/templates/deploy-service.yml
@@ -233,25 +233,25 @@ steps:
       - template: '../components/curl.yml'
         parameters:
           display_name: Add monitoring endpoints
-          ${{ if eq(parameters.apigee_environment, 'prod') }}:
-            url: "https://api.service.nhs.uk/monitoring-sd/service"
-          ${{ if not(eq(parameters.apigee_environment, 'prod')) }}:
-            url: "https://internal-dev.api.service.nhs.uk/monitoring-sd/service"
+          url: "https://internal-dev.api.service.nhs.uk/monitoring-sd/service"
           method: POST
           headers: "apikey: $(MONITORING_API_KEY)"
-          body: '{ "${{ parameters.service_name }}": { "${{ parameters.apigee_environment }}": [ "${{ parameters.service_name }}@${{ parameters.apigee_environment }}=http_2xx https://${{ parameters.apigee_environment }}.api.service.nhs.uk/${{ parameters.service_base_path }}/_ping" ] } }'
+          ${{ if eq(parameters.apigee_environment, 'prod') }}:
+            body: '{ "${{ parameters.service_name }}": { "${{ parameters.apigee_environment }}": [ "${{ parameters.service_name }}@${{ parameters.apigee_environment }}=http_2xx https://api.service.nhs.uk/${{ parameters.service_base_path }}/_ping" ] } }'
+          ${{ if not(eq(parameters.apigee_environment, 'prod')) }}:
+            body: '{ "${{ parameters.service_name }}": { "${{ parameters.apigee_environment }}": [ "${{ parameters.service_name }}@${{ parameters.apigee_environment }}=http_2xx https://${{ parameters.apigee_environment }}.api.service.nhs.uk/${{ parameters.service_base_path }}/_ping" ] } }'
 
   - ${{ if parameters.enable_status_monitoring  }}:
      - template: '../components/curl.yml'
        parameters:
         display_name: Add status endpoint
-        ${{ if eq(parameters.apigee_environment, 'prod') }}:
-         url: "https://api.service.nhs.uk/monitoring-sd/service"
-        ${{ if not(eq(parameters.apigee_environment, 'prod')) }}:
-         url: "https://internal-dev.api.service.nhs.uk/monitoring-sd/service"
+        url: "https://internal-dev.api.service.nhs.uk/monitoring-sd/service"
         method: POST
         headers: "apikey: $(MONITORING_API_KEY)"
-        body: '{ "${{ parameters.service_name }}": { "${{ parameters.apigee_environment }}": [ "${{ parameters.service_name }}@${{ parameters.apigee_environment }}=http_2xx https://${{ parameters.apigee_environment }}.api.service.nhs.uk/${{ parameters.service_base_path }}/_ping", "${{ parameters.service_name }}@${{ parameters.apigee_environment }}=http_2xx_with_api_key https://${{ parameters.apigee_environment }}.api.service.nhs.uk/${{ parameters.service_base_path }}/_status"  ] } }'
+        ${{ if eq(parameters.apigee_environment, 'prod') }}:
+          body: '{ "${{ parameters.service_name }}": { "${{ parameters.apigee_environment }}": [ "${{ parameters.service_name }}@${{ parameters.apigee_environment }}=http_2xx https://api.service.nhs.uk/${{ parameters.service_base_path }}/_ping", "${{ parameters.service_name }}@${{ parameters.apigee_environment }}=http_2xx_with_api_key https://api.service.nhs.uk/${{ parameters.service_base_path }}/_status"  ] } }'
+        ${{ if not(eq(parameters.apigee_environment, 'prod')) }}:
+          body: '{ "${{ parameters.service_name }}": { "${{ parameters.apigee_environment }}": [ "${{ parameters.service_name }}@${{ parameters.apigee_environment }}=http_2xx https://${{ parameters.apigee_environment }}.api.service.nhs.uk/${{ parameters.service_base_path }}/_ping", "${{ parameters.service_name }}@${{ parameters.apigee_environment }}=http_2xx_with_api_key https://${{ parameters.apigee_environment }}.api.service.nhs.uk/${{ parameters.service_base_path }}/_status"  ] } }'
 
   - ${{ each post_deploy_step in parameters.post_deploy }}:
     - ${{ post_deploy_step }}


### PR DESCRIPTION
## Summary
* Just use the internal-dev monitoring service for everything for now, until we have a separate prod instance
* Don't include env name when prod to prevent `prod.api...` from happenning
