### PR TITLE
APM-1733 Only check all apidocs on a 500 request and streamline

### DIFF
--- a/ansible/roles/deploy-apigee-product-and-spec/tasks/create-api-doc.yml
+++ b/ansible/roles/deploy-apigee-product-and-spec/tasks/create-api-doc.yml
@@ -19,32 +19,45 @@
         status_code: 200, 500
       register: create_apidoc
 
-    - name: get all apidocs
+    - name: verify apidoc creation on a 200 response
       uri:
-        url: "{{ portals_base_uri }}/{{ portal_id }}/apidocs"
+        url: "{{ portals_base_uri }}/{{ portal_id }}/apidocs/{{ create_apidoc.json.data.id }}"
         method: GET
         headers:
           Authorization: "Bearer {{ APIGEE_ACCESS_TOKEN }}"
         status_code: 200
         return_content: yes
-      register: apidocs
-
-    - name: set apidocs
-      set_fact:
-        apidocs: "{{ apidocs.json.data }}"
-
-    - name: get existing apidocs
-      set_fact:
-        existing_apidocs: "{{ apidocs | selectattr('edgeAPIProductName', '==', product.name)  | list }}"
+      when: create_apidoc.status == 200
     
-    - name: assert apidoc has been created!
-      assert:
-        that:
-          - "{{ existing_apidocs | length == 1 }}"
-        fail_msg:
-          - "reason: Failed updating apidoc" 
-          - "status: {{ create_apidoc.status }}"
-          - "error: {{ create_apidoc.msg }}"
+    - name: verify apidoc creation on a 500 response
+      block:
+        - name: get all apidocs
+          uri:
+            url: "{{ portals_base_uri }}/{{ portal_id }}/apidocs"
+            method: GET
+            headers:
+              Authorization: "Bearer {{ APIGEE_ACCESS_TOKEN }}"
+            status_code: 200
+            return_content: yes
+          register: apidocs
+
+        - name: set apidocs
+          set_fact:
+            apidocs: "{{ apidocs.json.data }}"
+
+        - name: get existing apidocs
+          set_fact:
+            existing_apidocs: "{{ apidocs | selectattr('edgeAPIProductName', '==', product.name)  | list }}"
+        
+        - name: assert apidoc has been created!
+          assert:
+            that:
+              - "{{ existing_apidocs | length == 1 }}"
+            fail_msg:
+              - "reason: Failed updating apidoc" 
+              - "status: {{ create_apidoc.status }}"
+              - "error: {{ create_apidoc.msg }}"
+      when: create_apidoc.status != 200
 
   rescue:
     - fail:

--- a/ansible/roles/deploy-apigee-product-and-spec/tasks/create-api-doc.yml
+++ b/ansible/roles/deploy-apigee-product-and-spec/tasks/create-api-doc.yml
@@ -18,16 +18,6 @@
           Authorization: "Bearer {{ APIGEE_ACCESS_TOKEN }}"
         status_code: 200, 500
       register: create_apidoc
-
-    - name: verify apidoc creation on a 200 response
-      uri:
-        url: "{{ portals_base_uri }}/{{ portal_id }}/apidocs/{{ create_apidoc.json.data.id }}"
-        method: GET
-        headers:
-          Authorization: "Bearer {{ APIGEE_ACCESS_TOKEN }}"
-        status_code: 200
-        return_content: yes
-      when: create_apidoc.status == 200
     
     - name: verify apidoc creation on a 500 response
       block:
@@ -57,7 +47,7 @@
               - "reason: Failed updating apidoc" 
               - "status: {{ create_apidoc.status }}"
               - "error: {{ create_apidoc.msg }}"
-      when: create_apidoc.status != 200
+      when: create_apidoc.status == 500
 
   rescue:
     - fail:

--- a/ansible/roles/deploy-apigee-product-and-spec/tasks/update-api-doc.yml
+++ b/ansible/roles/deploy-apigee-product-and-spec/tasks/update-api-doc.yml
@@ -21,7 +21,7 @@
 
     - name: get updated apidoc
       uri:
-        url: "{{ portals_base_uri }}/{{ portal_id }}/apidocs/{{ update_apidoc.json.data.id }}"
+        url: "{{ portals_base_uri }}/{{ portal_id }}/apidocs/{{ apidoc.id }}"
         method: GET
         headers:
           Authorization: "Bearer {{ APIGEE_ACCESS_TOKEN }}"

--- a/ansible/roles/deploy-apigee-product-and-spec/tasks/update-api-doc.yml
+++ b/ansible/roles/deploy-apigee-product-and-spec/tasks/update-api-doc.yml
@@ -19,32 +19,24 @@
         status_code: 200, 500
       register: update_apidoc
 
-    - name: get all apidocs, when update
+    - name: get updated apidoc
       uri:
-        url: "{{ portals_base_uri }}/{{ portal_id }}/apidocs"
+        url: "{{ portals_base_uri }}/{{ portal_id }}/apidocs/{{ update_apidoc.json.data.id }}"
         method: GET
         headers:
           Authorization: "Bearer {{ APIGEE_ACCESS_TOKEN }}"
         status_code: 200
         return_content: yes
-      register: apidocs
-
-    - name: set apidocs, when update
-      set_fact:
-        apidocs: "{{ apidocs.json.data }}"
-
-    - name: get existing apidocs, when update
-      set_fact:
-        existing_apidocs: "{{ apidocs | selectattr('edgeAPIProductName', '==', product.name) | list }}"
+      register: updated_apidoc
 
     - name: get epoch date
       command: date -u +%s
       register: epoch_date
 
-    - name: assert only apidoc has been updated
+    - name: assert apidoc has been updated
       assert:
         that:
-          - "{{ (epoch_date.stdout_lines[0] | int) - (existing_apidocs[0].modified / 1000) < 30 }}"
+          - "{{ (epoch_date.stdout_lines[0] | int) - (updated_apidoc.json.data.modified / 1000) < 30 }}"
         fail_msg:
           - "reason: Failed updating apidoc" 
           - "status: {{ update_apidoc.status }}"

--- a/ansible/roles/deploy-apigee-product-and-spec/tasks/update-snapshot.yml
+++ b/ansible/roles/deploy-apigee-product-and-spec/tasks/update-snapshot.yml
@@ -21,7 +21,7 @@
         status_code: 200, 500
       register: snapshot
 
-    - name: get updated apidoc
+    - name: get updated apidoc, on snapshot update
       uri:
         url: "{{ portals_base_uri }}/{{ portal_id }}/apidocs/{{ apidoc.id }}"
         method: GET

--- a/ansible/roles/deploy-apigee-product-and-spec/tasks/update-snapshot.yml
+++ b/ansible/roles/deploy-apigee-product-and-spec/tasks/update-snapshot.yml
@@ -12,7 +12,7 @@
       set_fact:
         apidoc: "{{ create_apidoc.json.data | default(update_apidoc.json.data) }}"
 
-    - name: Update remote snapshot
+    - name: update remote snapshot
       uri:
         url: "{{ portals_base_uri }}/{{ portal_id }}/apidocs/{{ apidoc.id }}/snapshot"
         method: "{{ (SPEC_FILE) | ternary('PUT', 'DELETE') }}"
@@ -21,23 +21,15 @@
         status_code: 200, 500
       register: snapshot
 
-    - name: get all apidocs, on snapshot update
+    - name: get updated apidoc
       uri:
-        url: "{{ portals_base_uri }}/{{ portal_id }}/apidocs"
+        url: "{{ portals_base_uri }}/{{ portal_id }}/apidocs/{{ apidoc.id }}"
         method: GET
         headers:
           Authorization: "Bearer {{ APIGEE_ACCESS_TOKEN }}"
         status_code: 200
         return_content: yes
-      register: apidocs
-
-    - name: set apidocs, on snapshot update
-      set_fact:
-        apidocs: "{{ apidocs.json.data }}"
-
-    - name: get existing apidocs, on snapshot update
-      set_fact:
-        existing_apidocs: "{{ apidocs | selectattr('edgeAPIProductName', '==', product.name) | list }}"
+      register: updated_snapshot
 
     - name: get epoch date
       command: date -u +%s
@@ -46,7 +38,7 @@
     - name: assert snapshot has been updated
       assert:
         that:
-          - "{{ (epoch_date.stdout_lines[0] | int) - (existing_apidocs[0].snapshotModified / 1000) < 30 }}"
+          - "{{ (epoch_date.stdout_lines[0] | int) - (updated_snapshot.json.data.snapshotModified / 1000) < 30 }}"
         fail_msg:
           - "reason: Failed updating snapshot" 
           - "status: {{ snapshot.status }}"


### PR DESCRIPTION
## Summary
* Streamline validation for api docs
* only check all apidocs for duplicates if a 500 is returned from apigee

Add any other relevant notes or explanations here. **Remove this line if you have nothing to add.**
