### PR TITLE
APM-1701 remove dev as deploy environment

### DIFF
--- a/azure/common/apigee-deployment.yml
+++ b/azure/common/apigee-deployment.yml
@@ -130,7 +130,6 @@ parameters:
           - internal-dev-sandbox
           - internal-qa
           - internal-qa-sandbox
-          - dev
           - ref
           - int
           - sandbox

--- a/azure/common/deploy-stage.yml
+++ b/azure/common/deploy-stage.yml
@@ -12,7 +12,6 @@ parameters:
       - internal-qa
       - internal-qa-sandbox
       - ref
-      - dev
       - int
       - sandbox
       - prod

--- a/azure/common/release.yml
+++ b/azure/common/release.yml
@@ -6,7 +6,6 @@ parameters:
       - internal-qa
       - internal-qa-sandbox
       - ref
-      - dev
       - int
       - sandbox
       - prod


### PR DESCRIPTION
## Summary
remove dev as deployment environment since apis-dev ECS cluster no longer exist
