### PR TITLE
Swap back to default role after pre_template

### DIFF
--- a/azure/templates/deploy-service.yml
+++ b/azure/templates/deploy-service.yml
@@ -81,6 +81,14 @@ steps:
   - ${{ each pre_template_step in parameters.pre_template }}:
     - ${{ pre_template_step }}
 
+  # pre_template steps might have been doing cross account stuff
+  # make sure we bring everything back to the correct AWS role here
+  - template: ../components/aws-assume-role.yml
+    parameters:
+      role: "auto-ops"
+      profile: "apm_${{ parameters.aws_account }}"
+      aws_account: "${{ parameters.aws_account }}"
+
   - ${{ if parameters.jinja_templates }}:
       - bash: mkdir -p group_vars/all && touch jinja_templates.yml
         workingDirectory: "$(UTILS_DIR)/ansible/"


### PR DESCRIPTION
## Summary
* Routine Change
* :warning: Potential issues that might be caused by this change

Ensures the AWS context is changed back to the APIM default after pre_template steps have been run