### PR TITLE
APM-2321 add producer manual approval for prod

### DIFF
--- a/azure/common/apigee-deployment.yml
+++ b/azure/common/apigee-deployment.yml
@@ -78,6 +78,10 @@ parameters:
     displayName: Requires manual approval
     type: boolean
     default: true
+  - name: prod_producer_approval
+    displayName: Requires producer manual approval
+    type: boolean
+    default: false
   - name: manual_approval_env
     displayName: Custom manual approval env overwrite
     type: string
@@ -163,12 +167,20 @@ extends:
           apigee_deployments:
             - ${{ each apigee_deployment in parameters.apigee_deployments }}:
               - ${{ if and(eq(apigee_deployment.environment, 'prod'), parameters.prod_requires_approval) }}:
-                - environment: manual-approval
-                  stage_name: manual_approval
-                  depends_on: []
-                  manual_approval_prod: true
-                  ${{ each var in parameters._scoped_pipeline_vars }}:
-                      ${{ var }}: ${{ parameters[var] }}
+                  ${{ if and(eq(apigee_deployment.environment, 'prod'), parameters.prod_producer_approval) }}:
+                    - environment: ${{ parameters.service_name }}
+                      stage_name: manual_approval
+                      depends_on: []
+                      manual_approval_prod: true
+                      ${{ each var in parameters._scoped_pipeline_vars }}:
+                          ${{ var }}: ${{ parameters[var] }}
+                  ${{ if and(eq(apigee_deployment.environment, 'prod'), not(parameters.prod_producer_approval)) }}:
+                    - environment: manual-approval
+                      stage_name: manual_approval
+                      depends_on: []
+                      manual_approval_prod: true
+                      ${{ each var in parameters._scoped_pipeline_vars }}:
+                          ${{ var }}: ${{ parameters[var] }}
             - ${{ each apigee_deployment in parameters.apigee_deployments }}:
               - environment: ${{ apigee_deployment.environment }}
                 stage_name: ${{ replace(coalesce (apigee_deployment.stage_name, apigee_deployment.environment), '-', '_') }}

--- a/azure/common/apigee-deployment.yml
+++ b/azure/common/apigee-deployment.yml
@@ -167,13 +167,13 @@ extends:
           apigee_deployments:
             - ${{ each apigee_deployment in parameters.apigee_deployments }}:
               - ${{ if and(eq(apigee_deployment.environment, 'prod'), parameters.prod_requires_approval) }}:
-                  - environment: manual-approval
-                    stage_name: manual_approval
-                    depends_on: []
-                    manual_approval_prod: true
-                    producer_approval: ${{ paramaters.prod_producer_approval }}
-                    ${{ each var in parameters._scoped_pipeline_vars }}:
-                        ${{ var }}: ${{ parameters[var] }}
+                - environment: manual-approval
+                  stage_name: manual_approval
+                  depends_on: []
+                  manual_approval_prod: true
+                  producer_approval: ${{ paramaters.prod_producer_approval }}
+                  ${{ each var in parameters._scoped_pipeline_vars }}:
+                      ${{ var }}: ${{ parameters[var] }}
             - ${{ each apigee_deployment in parameters.apigee_deployments }}:
               - environment: ${{ apigee_deployment.environment }}
                 stage_name: ${{ replace(coalesce (apigee_deployment.stage_name, apigee_deployment.environment), '-', '_') }}

--- a/azure/common/apigee-deployment.yml
+++ b/azure/common/apigee-deployment.yml
@@ -167,14 +167,14 @@ extends:
           apigee_deployments:
             - ${{ each apigee_deployment in parameters.apigee_deployments }}:
               - ${{ if and(eq(apigee_deployment.environment, 'prod'), parameters.prod_requires_approval) }}:
-                  ${{ if and(eq(apigee_deployment.environment, 'prod'), parameters.prod_producer_approval) }}:
+                  - ${{ if and(eq(apigee_deployment.environment, 'prod'), parameters.prod_producer_approval) }}:
                     - environment: ${{ parameters.service_name }}
                       stage_name: manual_approval
                       depends_on: []
                       manual_approval_prod: true
                       ${{ each var in parameters._scoped_pipeline_vars }}:
                           ${{ var }}: ${{ parameters[var] }}
-                  ${{ if and(eq(apigee_deployment.environment, 'prod'), not(parameters.prod_producer_approval)) }}:
+                  - ${{ if and(eq(apigee_deployment.environment, 'prod'), not(parameters.prod_producer_approval)) }}:
                     - environment: manual-approval
                       stage_name: manual_approval
                       depends_on: []

--- a/azure/common/apigee-deployment.yml
+++ b/azure/common/apigee-deployment.yml
@@ -171,7 +171,7 @@ extends:
                   stage_name: manual_approval
                   depends_on: []
                   manual_approval_prod: true
-                  producer_approval: ${{ paramaters.prod_producer_approval }}
+                  producer_approval: ${{ parameters.prod_producer_approval }}
                   ${{ each var in parameters._scoped_pipeline_vars }}:
                       ${{ var }}: ${{ parameters[var] }}
             - ${{ each apigee_deployment in parameters.apigee_deployments }}:

--- a/azure/common/apigee-deployment.yml
+++ b/azure/common/apigee-deployment.yml
@@ -172,6 +172,7 @@ extends:
                       stage_name: manual_approval
                       depends_on: []
                       manual_approval_prod: true
+                      producer_approval: true
                       ${{ each var in parameters._scoped_pipeline_vars }}:
                           ${{ var }}: ${{ parameters[var] }}
                   - ${{ if and(eq(apigee_deployment.environment, 'prod'), not(parameters.prod_producer_approval)) }}:

--- a/azure/common/apigee-deployment.yml
+++ b/azure/common/apigee-deployment.yml
@@ -167,21 +167,13 @@ extends:
           apigee_deployments:
             - ${{ each apigee_deployment in parameters.apigee_deployments }}:
               - ${{ if and(eq(apigee_deployment.environment, 'prod'), parameters.prod_requires_approval) }}:
-                  - ${{ if and(eq(apigee_deployment.environment, 'prod'), parameters.prod_producer_approval) }}:
-                    - environment: ${{ parameters.service_name }}
-                      stage_name: manual_approval
-                      depends_on: []
-                      manual_approval_prod: true
-                      producer_approval: true
-                      ${{ each var in parameters._scoped_pipeline_vars }}:
-                          ${{ var }}: ${{ parameters[var] }}
-                  - ${{ if and(eq(apigee_deployment.environment, 'prod'), not(parameters.prod_producer_approval)) }}:
-                    - environment: manual-approval
-                      stage_name: manual_approval
-                      depends_on: []
-                      manual_approval_prod: true
-                      ${{ each var in parameters._scoped_pipeline_vars }}:
-                          ${{ var }}: ${{ parameters[var] }}
+                  - environment: manual-approval
+                    stage_name: manual_approval
+                    depends_on: []
+                    manual_approval_prod: true
+                    producer_approval: ${{ paramaters.prod_producer_approval }}
+                    ${{ each var in parameters._scoped_pipeline_vars }}:
+                        ${{ var }}: ${{ parameters[var] }}
             - ${{ each apigee_deployment in parameters.apigee_deployments }}:
               - environment: ${{ apigee_deployment.environment }}
                 stage_name: ${{ replace(coalesce (apigee_deployment.stage_name, apigee_deployment.environment), '-', '_') }}

--- a/azure/common/deploy-stages.yml
+++ b/azure/common/deploy-stages.yml
@@ -12,6 +12,9 @@ parameters:
   - name: prod_requires_approval
   - name: manual_approval_env
     type: string
+  - name: prod_producer_approval
+    type: boolean
+
 
 
 stages:

--- a/azure/common/deploy-stages.yml
+++ b/azure/common/deploy-stages.yml
@@ -23,7 +23,7 @@ stages:
       parameters:
         ${{ insert }}: ${{ apigee_deployment }}
         ${{ each param in parameters }}:
-          ${{ if notIn(param.key, 'deploy_template', 'apigee_deployments', 'deploy_review_sandbox', 'prod_requires_approval') }}:
+          ${{ if notIn(param.key, 'deploy_template', 'apigee_deployments', 'deploy_review_sandbox', 'prod_requires_approval', 'prod_producer_approval') }}:
             ${{ param.key }}: ${{ param.value }}
 
         # Compute the apigee organization & org level part of the AWS secret/config path

--- a/azure/common/release.yml
+++ b/azure/common/release.yml
@@ -81,5 +81,5 @@ stages:
         ${{ if ne('', parameters.fully_qualified_service_name) }}:
           fully_qualified_service_name: ${{ parameters.fully_qualified_service_name }}
         ${{ each param in parameters }}:
-          ${{ if notIn(param.key, 'fully_qualified_service_name', 'manual_approval_env', 'manual_approval_prod') }}:
+          ${{ if notIn(param.key, 'fully_qualified_service_name', 'manual_approval_env', 'manual_approval_prod', 'producer_approval') }}:
             ${{ param.key }}: ${{ param.value }}

--- a/azure/common/release.yml
+++ b/azure/common/release.yml
@@ -57,6 +57,9 @@ parameters:
   - name: manual_approval_prod
     type: boolean
     default: false
+  - name: producer_approval
+    type: boolean
+    default: false
 
 stages:
   - ${{ if eq(parameters.environment, 'manual-approval') }}:
@@ -64,7 +67,9 @@ stages:
       parameters:
         stage_name: ${{ parameters.stage_name }}
         depends_on: ${{ parameters.depends_on }}
-        ${{ if eq(true, parameters.manual_approval_prod) }}:
+        ${{ if and(eq(true, parameters.manual_approval_prod), eq(true, parameters.producer_approval)) }}:
+          manual_approval_env: ${{ parameters.service_name }}
+        ${{ if and(eq(true, parameters.manual_approval_prod), eq(false, parameters.producer_approval)) }}:
           manual_approval_env: manual-approval-prod
         ${{ if eq(false, parameters.manual_approval_prod) }}:
           manual_approval_env: ${{ parameters.manual_approval_env }}


### PR DESCRIPTION
## Summary

This topic came up in the release process retro on 28/01/2022.

The scope is for example API Producer

Acceptance Criteria

Exemplar producer team has its own manual approval environment 
Azure DevOps team was created to manage this, which includes producer team members only
Azure DevOps team + platform admins set as approvers on manual approvals environment
Common pipelines configured to allow API-specific manual approval environs on prod
The producer environment can't be overwritten
Producer zone
first time into the production section on setting up self-approval
Any changes to release management pages
KOP on how to set up team/env and users
Manually tested with Canary API
