### PR TITLE
Added failing step to check slack failure notifications

### DIFF
--- a/azure/cleanup-ecs-pr-proxies.yml
+++ b/azure/cleanup-ecs-pr-proxies.yml
@@ -25,6 +25,10 @@ jobs:
 
       - checkout: self
 
+      - bash: exit 1
+        displayName: Fail on purpose to test slack notification
+        condition: eq('test', 'test')
+
       - bash: |
           instance_id="$(curl -s http://169.254.169.254/latest/meta-data/instance-id)"
           echo instance-id: "${instance_id}"

--- a/azure/cleanup-pr-portal-apis-and-specs.yml
+++ b/azure/cleanup-pr-portal-apis-and-specs.yml
@@ -25,6 +25,7 @@ jobs:
       - checkout: self
 
       - bash: |
+          exit 1
           instance_id="$(curl -s http://169.254.169.254/latest/meta-data/instance-id)"
           echo instance-id: "${instance_id}"
           echo connect to: https://eu-west-2.console.aws.amazon.com/systems-manager/session-manager/${instance_id}


### PR DESCRIPTION
## Summary
* Routine Change
* :exclamation: Breaking Change
* :robot: Operational or Infrastructure Change
* :sparkles: New Feature
* :warning: Potential issues that might be caused by this change

Just testing build failure notifications for slack
