### PR TITLE
Update urls to point at prod

### DIFF
--- a/ansible/collections/ansible_collections/nhsd/apigee/plugins/module_utils/paas/urls.py
+++ b/ansible/collections/ansible_collections/nhsd/apigee/plugins/module_utils/paas/urls.py
@@ -12,4 +12,4 @@ def _localstack() -> bool:
 def api_registry() -> str:
     if _localstack():
         return "http://localhost:9000"
-    return "https://api-registry.ptl.api.platform.nhs.uk:9000"
+    return "https://api-registry.prod.api.platform.nhs.uk:9000"

--- a/azure/common/deploy-stage.yml
+++ b/azure/common/deploy-stage.yml
@@ -223,7 +223,7 @@ stages:
                 - bash: |
                     set -euo pipefail
 
-                    INFO=$(curl https://api-registry.ptl.api.platform.nhs.uk:9000/api/${{ parameters.service_name }})
+                    INFO=$(curl https://api-registry.prod.api.platform.nhs.uk:9000/api/${{ parameters.service_name }})
                     SHORT_NAME=$(echo $INFO | jq -r .short_name)
                     GUID=$(echo $INFO | jq -r .guid)
 


### PR DESCRIPTION
Api registry data has been copied from ptl dynamo db table to prod dynamo db table. This PR is to update where Utils pulls its values from.
