### PR TITLE
HOSTED_TARGET_CONNECTION_PATH_SUFFIX passing to proxy templates

### DIFF
--- a/ansible/template-proxies.yml
+++ b/ansible/template-proxies.yml
@@ -19,6 +19,8 @@
     DEPLOYED_VERSION: "{{ lookup('env', 'DEPLOYED_VERSION') }}"
     RELEASE_RELEASEID: "{{ lookup('env', 'RELEASE_RELEASEID') }}"
     SOURCE_COMMIT_ID: "{{ lookup('env', 'SOURCE_COMMIT_ID') }}"
+    HOSTED_TARGET_CONNECTION_PATH_SUFFIX: "{{ lookup('env', 'HOSTED_TARGET_CONNECTION_PATH_SUFFIX') }}"
+    HOSTED_TARGET_HEALTHCHECK_SUFFIX: "{{ lookup('env', 'HOSTED_TARGET_HEALTHCHECK_SUFFIX') }}"
     HOSTED_TARGET_CONNECTION: |
           <SSLInfo>
             <Enabled>true</Enabled>


### PR DESCRIPTION
## Summary

The `HOSTED_TARGET_CONNECTION_PATH_SUFFIX` variable is referenced for constructing the path value within the `HOSTED_TARGET_CONNECTION` variable.

This variable was not instantiated from the environmental variable that holds the value that has been configured within your API-M pipelines/variables.

The same issue was affecting `HOSTED_TARGET_HEALTHCHECK_SUFFIX`.

This PR adds the instantiation of these values from env within template-proxies.yml.