### PR TITLE
host_target_healthcheck_suffix defaults

### DIFF
--- a/ansible/template-proxies.yml
+++ b/ansible/template-proxies.yml
@@ -36,7 +36,7 @@
       <LoadBalancer>
         <Server name="hosted-apis"/>
       </LoadBalancer>
-      <Path>/{{ service_id }}{{ '-' + pr_number if pr_number else '' }}{{ HOSTED_TARGET_HEALTHCHECK_SUFFIX | default('/_status') }}</Path>
+      <Path>/{{ service_id }}{{ '-' + pr_number if pr_number else '' }}{{ HOSTED_TARGET_HEALTHCHECK_SUFFIX | default('') }}</Path>
    
 
   roles:

--- a/azure/common/apigee-deployment.yml
+++ b/azure/common/apigee-deployment.yml
@@ -33,7 +33,7 @@ parameters:
     default: ''
   - name: hosted_target_healthcheck_suffix
     type: string
-    default: ''
+    default: '/_status'
   - name: jinja_templates
     type: object
     displayName:  Key/values for custom jinja templating

--- a/azure/common/pr.yml
+++ b/azure/common/pr.yml
@@ -52,7 +52,7 @@ parameters:
     default: ''
   - name: hosted_target_healthcheck_suffix
     type: string
-    default: ''
+    default: '/_status'
   - name: manual_approval_env
     type: string
 


### PR DESCRIPTION
## Summary

Moves the default value for the `host_target_healthcheck_suffix` value to being defined within the pipeline definitions rather than in ansible.

This attempts to correct a bug introduced with https://github.com/NHSDigital/api-management-utils/pull/438.

The previous PR allowed this value to be configurable - where as before it was always resolving to the defaulted `/_status` within the ansible variable `HOSTED_TARGET_HEALTHCHECK` - it was defaulting to the value of an empty string. If you configured the `host_target_healthcheck_suffix` variable within your pipelines to `/_status` then this would not cause you issues.