### PR TITLE
CCM-1179

### DIFF
--- a/azure/templates/deploy-service.yml
+++ b/azure/templates/deploy-service.yml
@@ -132,7 +132,7 @@ steps:
         export RELEASE_RELEASEID=$(Build.BuildId)
 
         if [[ $SERVICE_ARTIFACT_NAME == v* ]]; then
-          export DEPLOYED_VERSION=`echo $SERVICE_ARTIFACT_NAME | grep -o "v[0-9]\+\.[0-9]\+\.[0-9]\+-[[:alpha:]]\+" | tail -1`
+          export DEPLOYED_VERSION=`echo $SERVICE_ARTIFACT_NAME | grep -E -o "v[0-9]+\.[0-9]+\.[0-9]+-?[a-z]*" | tail -1`
         else
           export DEPLOYED_VERSION="${{ parameters.fully_qualified_service_name }}"
         fi
@@ -203,7 +203,7 @@ steps:
       source $(SERVICE_DIR)/.build_env_vars
 
       if [[ $SERVICE_ARTIFACT_NAME == v* ]]; then
-        export DEPLOYED_VERSION=`echo $SERVICE_ARTIFACT_NAME | grep -o "v[0-9]\+\.[0-9]\+\.[0-9]\+-[[:alpha:]]\+" | tail -1`
+        export DEPLOYED_VERSION=`echo $SERVICE_ARTIFACT_NAME | grep -E -o "v[0-9]+\.[0-9]+\.[0-9]+-?[a-z]*" | tail -1`
       else
         export DEPLOYED_VERSION="${{ parameters.fully_qualified_service_name }}"
       fi


### PR DESCRIPTION
## Summary

There is a regular expression which evaluates the value in `SERVICE_ARTIFACT_NAME` to determine the version of the deployed version.

Unfortunately this doesn't work for tagged versions where there is no suffix value (-alpha etc).

This PR updates the regex to allow for versions with a suffix and without.

When we deployed prior to this change our `/_ping` endpoint would return an empty version identifier:

![image](https://github.com/NHSDigital/api-management-utils/assets/879532/0bbd95e2-51a4-4597-b183-34ed0ab2822e)

Post deployment with this fix, this value is populated correctly:

![image](https://github.com/NHSDigital/api-management-utils/assets/879532/3ce61cc7-a187-4fb8-a32c-5e10ad812c23)
