### PR TITLE
APM-4363 changes to support ALB sharding

### DIFF
--- a/ansible/roles/create-api-deployment-pre-reqs/templates/terraform/iam.tf
+++ b/ansible/roles/create-api-deployment-pre-reqs/templates/terraform/iam.tf
@@ -265,11 +265,11 @@ data "aws_iam_policy_document" "deploy-user" {
     ]
     resources = concat(
       [
-        "arn:aws:elasticloadbalancing:${local.region}:${local.account_id}:listener/app/apis-${var.apigee_environment}/*",
         "arn:aws:elasticloadbalancing:${local.region}:${local.account_id}:listener-rule/app/apis-${var.apigee_environment}/*",
         "arn:aws:elasticloadbalancing:${local.region}:${local.account_id}:listener/app/apis-public-${var.apigee_environment}/*",
         "arn:aws:elasticloadbalancing:${local.region}:${local.account_id}:listener-rule/app/apis-public-${var.apigee_environment}/*",
       ],
+      [for listener in local.private_alb_listeners : listener.arn],
       [for ns in local.short_env_service_namespaces : "arn:aws:elasticloadbalancing:${local.region}:${local.account_id}:targetgroup/${ns}/*"],
       [for ns in local.service_namespaces : "arn:aws:ecs:${local.region}:${local.account_id}:service/apis-${var.apigee_environment}/${ns}"]
     )

--- a/ansible/roles/create-api-deployment-pre-reqs/templates/terraform/locals.tf
+++ b/ansible/roles/create-api-deployment-pre-reqs/templates/terraform/locals.tf
@@ -12,9 +12,8 @@ locals {
   short_env_service_namespaces = [for ns in local.service_namespaces : "${var.apigee_shortenv}-${ns}"]
   workspaces             = contains(["internal-dev", "internal-dev-sandbox"], var.apigee_environment) ? [var.workspace, "${var.workspace}:*"] : [var.workspace]
 
-
-  private_alb_listener = data.terraform_remote_state.account.outputs.apis.alb-listener.private[var.apigee_environment]
-  private_alb          = data.terraform_remote_state.account.outputs.apis.alb.private[var.apigee_environment]
+  private_alb_listeners = data.terraform_remote_state.account.outputs.apis.alb-listener.private[var.apigee_environment]
+  private_albs          = data.terraform_remote_state.account.outputs.apis.alb.private[var.apigee_environment]
   ecs_cluster         = data.terraform_remote_state.account.outputs.apis.ecs_clusters[var.apigee_environment]
   apis_subdomain      = data.terraform_remote_state.account.outputs.apis.apis_subdomain
 

--- a/ansible/roles/create-api-deployment-pre-reqs/templates/terraform/outputs.tf
+++ b/ansible/roles/create-api-deployment-pre-reqs/templates/terraform/outputs.tf
@@ -3,12 +3,16 @@ output "vpc_id" {
   value = data.terraform_remote_state.account.outputs.account_vpc.id
 }
 
-output "private_alb_listener_arn" {
-  value = local.private_alb_listener.arn
+output "private_alb_listener_arns" {
+  value = [for listener in local.private_alb_listeners : listener.arn]
 }
 
-output "private_alb_arn_suffix" {
-  value = local.private_alb.arn_suffix
+output "private_alb_listener_count" {
+  value = data.terraform_remote_state.account.outputs.apis.alb-listener-count
+}
+
+output "private_alb_arn_suffixes" {
+  value = [for alb in local.private_albs : alb.arn_suffix]
 }
 
 output "subnet_ids" {

--- a/ansible/roles/deploy-ecs-proxies/templates/terraform/alb.tf
+++ b/ansible/roles/deploy-ecs-proxies/templates/terraform/alb.tf
@@ -18,14 +18,14 @@ resource "aws_alb_target_group" "service" {
 }
 
 resource "aws_lb_listener_rule" "service" {
-  listener_arn = data.terraform_remote_state.pre-reqs.outputs.private_alb_listener_arn
-
+  listener_arn = local.private_alb_listener_arns[
+    parseint(md5(local.short_env_namespaced_name), 16) % local.private_alb_listener_count
+  ]
   action {
     order            = 1
     target_group_arn = aws_alb_target_group.service.arn
     type             = "forward"
   }
-
   condition {
     http_header {
       http_header_name = "X-APIM-Service"

--- a/ansible/roles/deploy-ecs-proxies/templates/terraform/fargate.tf
+++ b/ansible/roles/deploy-ecs-proxies/templates/terraform/fargate.tf
@@ -89,10 +89,7 @@ resource "aws_appautoscaling_target" "ecs_target" {
   service_namespace  = "ecs"
 }
 
-
 resource "aws_appautoscaling_policy" "ecs_policy" {
-
-  count = var.autoscaling_enabled ? 1 : 0
 
   name               = local.short_env_namespaced_name
   policy_type        = "TargetTrackingScaling"
@@ -103,10 +100,11 @@ resource "aws_appautoscaling_policy" "ecs_policy" {
   target_tracking_scaling_policy_configuration {
     predefined_metric_specification {
       predefined_metric_type = var.autoscaling_service_metric
-      resource_label = local.autoscaling_resource_label
+      resource_label = each.key
     }
     scale_out_cooldown = var.autoscaling_scale_out_cooldown
     scale_in_cooldown = var.autoscaling_scale_in_cooldown
     target_value = var.autoscaling_target_value
   }
+  for_each = var.autoscaling_enabled ? toset(local.autoscaling_resource_labels) : toset([])
 }

--- a/ansible/roles/deploy-ecs-proxies/templates/terraform/locals.tf
+++ b/ansible/roles/deploy-ecs-proxies/templates/terraform/locals.tf
@@ -58,10 +58,12 @@ locals {
 
   exposed_service = element(matchkeys(local.ecs_service, local.ecs_service.*.expose, list(true)), 0)
 
-  private_alb_arn_suffix = data.terraform_remote_state.pre-reqs.outputs.private_alb_arn_suffix
+  private_alb_arn_suffixes = data.terraform_remote_state.pre-reqs.outputs.private_alb_arn_suffixes
+  private_alb_listener_arns = data.terraform_remote_state.pre-reqs.outputs.private_alb_listener_arns
+  private_alb_listener_count = data.terraform_remote_state.pre-reqs.outputs.private_alb_listener_count
 
-  autoscaling_resource_label =  (
-    var.autoscaling_enabled && var.autoscaling_service_metric == "ALBRequestCountPerTarget" ?
-      "${local.private_alb_arn_suffix}/${aws_alb_target_group.service.arn_suffix}" : ""
-  )
+  autoscaling_resource_labels =  [
+    for suffix in data.terraform_remote_state.pre-reqs.outputs.private_alb_arn_suffixes : (
+      var.autoscaling_enabled && var.autoscaling_service_metric == "ALBRequestCountPerTarget" ? "${suffix}/${aws_alb_target_group.service.arn_suffix}"
+      : "")]
 }

--- a/azure/common/apigee-build.yml
+++ b/azure/common/apigee-build.yml
@@ -212,7 +212,7 @@ jobs:
 
       - bash: |
           tfenv use 0.14.6
-        displayName: use terraforn
+        displayName: use terraform
         condition: and(succeeded(), eq(variables['build_containers'], 'true'))
 
       - bash: |


### PR DESCRIPTION
* `/ansible/roles/create-api-deployment-pre-reqs/` contains changes for data on ALBs to be captured / recorded for the `deploy-ecs-proxies` playbook
* `/ansible/roles/deploy-ecs-proxies/templates/terraform/alb.tf` is where we point traffic towards a _specific_ ALB
* `/ansible/roles/deploy-ecs-proxies/templates/terraform/fargate.tf` is updating the autoscaling policy to look across each ALB instance
* `/azure/common/` is a random typo fix lol