### PR TITLE
CCM-981

### DIFF
--- a/azure/components/get-access-token.yml
+++ b/azure/components/get-access-token.yml
@@ -22,12 +22,15 @@ steps:
 
   - bash: |
       set -euo pipefail
+
+      # fetch the access token
       curl -X POST https://${{ parameters._auth_server[parameters.apigee_organization] }}/oauth/token \
         -H "Content-Type: application/x-www-form-urlencoded" \
         -H "Accept: application/json;charset=utf-8" \
         -H "Authorization: Basic ZWRnZWNsaTplZGdlY2xpc2VjcmV0" \
-        -d "username=${{ parameters.apigee_username }}&password=${{ parameters.apigee_password }}&mfa_token=$(secret.MFACode)&grant_type=password" | jq .access_token > .token
+        -d "username=${{ parameters.apigee_username }}&password=${{ parameters.apigee_password }}&mfa_token=$(secret.MFACode)&grant_type=password" | jq -e .access_token > .token
 
       # Set token into variable
       echo "##vso[task.setvariable variable=secret.AccessToken;issecret=true]`cat .token`"
     displayName: 'Get Apigee Access Token'
+    retryCountOnTaskFailure: 5


### PR DESCRIPTION
## Summary

Periodically this step in the pipeline will fail - this requires APIM producers to have to press the retry button in order to get a successful build. The manual retry process is normally successful after only 1 retry.

The error thrown here is a 401 - this makes me believe that token created within the `Get Apigee Access Token` step was failing.

`jq` is being used to extract the `.access_token` path from the JSON response - previously it was not returning an error code when the payload did not contain the path. This updates the `jq` call with the `-e` flag which will error when `.access_token` is not within the response.

An automated retry mechanism for when this error occurs has been added to this step. It uses the built in azure devops retryCountOnTaskFailure which will automatically back off on subsequent failures.

See https://learn.microsoft.com/en-us/azure/devops/pipelines/process/tasks?view=azure-devops&tabs=yaml#number-of-retries-if-task-failed

