### PR TITLE
Ccm 5956 fix rate limit not applied to pr proxies

### DIFF
--- a/ansible/collections/ansible_collections/nhsd/apigee/plugins/module_utils/models/ansible/apply_pull_request_namespace.py
+++ b/ansible/collections/ansible_collections/nhsd/apigee/plugins/module_utils/models/ansible/apply_pull_request_namespace.py
@@ -55,7 +55,19 @@ class ApplyPullRequestNamespace(pydantic.BaseModel):
                     else proxy
                     for proxy in product.proxies
                 ]
-
+                
+                for attribute in product.attributes:
+                    if attribute.name != 'ratelimit':
+                        continue
+                    
+                    new_value = {}
+                    for key in attribute.value.keys():
+                        if key.startswith(api_name):
+                            new_value[key.replace(old, new)] = attribute.value[key]
+                        else:
+                            new_value[key] = attribute.value[key]
+                    
+                    attribute.value = new_value
             for spec in env.specs:
                 spec.name = spec.name.replace(old, new, 1)
             


### PR DESCRIPTION
## Summary
* :robot: Operational or Infrastructure Change

This is an attempt to fix an issues where API Proxy rate limits are not apply to apigee proxies deployed as part of a PR. This is because one of the rate limit attribute in the manifest need to use the proxy name in order to be picked by the shared flow. Therefore that proxy name needs `internal-dev` replaced by the actual PR number, for example `pr-712` in order to work.

I didn't manage to test this PR.
