### PR TITLE
BAU-14135: Make python version configurable in build

### DIFF
--- a/azure/common/apigee-build.yml
+++ b/azure/common/apigee-build.yml
@@ -27,6 +27,9 @@ parameters:
   - name: cache_steps
     type: stepList
     default: []
+  - name: python_version
+    type: string
+    default: "3.8"
 
 jobs:
   - job: build
@@ -138,9 +141,9 @@ jobs:
           service_name: "${{ parameters.service_name }}"
 
       - task: UsePythonVersion@0
-        displayName: "Use Python 3.8"
+        displayName: "Use Python ${{ parameters.python_version }}"
         inputs:
-          versionSpec: "3.8"
+          versionSpec: ${{ parameters.python_version }}
 
       - ${{ each cache_step in parameters.cache_steps }}:
           - ${{ cache_step }}


### PR DESCRIPTION
## Summary
* Routine Change

Makes the installed python version configurable, leaving 3.8 as the default so as to not make this a breaking change.
